### PR TITLE
[Refactor] Rewrite TorchKGE where relevant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ dist/
 *.egg-info/
 __pycache__
 _build/
+build/
 poetry.lock

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -35,7 +35,6 @@ from torchkge.models import Model
 import torchkge.sampling as sampling
 from torchkge.utils import MarginLoss, BinaryCrossEntropyLoss
 
-
 from .data_leakage import permute_tails
 from .decoders import *
 from .encoders import *

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -19,7 +19,7 @@ import yaml
 
 import torch
 from torch import tensor, Tensor
-from torch.nn import Parameter
+from torch.nn import Parameter, Module
 import torch.optim as optim
 from torch.optim import lr_scheduler as learning_rate_scheduler
 from torch.utils.data import DataLoader
@@ -30,8 +30,6 @@ from ignite.metrics import RunningAverage
 
 from torch_geometric.utils import k_hop_subgraph
 
-from torchkge import KnowledgeGraph
-from torchkge.models import Model
 import torchkge.sampling as sampling
 from torchkge.utils import MarginLoss, BinaryCrossEntropyLoss
 
@@ -55,7 +53,7 @@ logging.basicConfig(
 )
 
 
-class Architect(Model):
+class Architect(Module):
     """
     Architect class for knowledge graph embedding training.
     

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -32,7 +32,6 @@ from ignite.metrics import RunningAverage
 
 from torch_geometric.utils import k_hop_subgraph
 
-import torchkge.sampling as sampling
 from torchkge.utils import MarginLoss, BinaryCrossEntropyLoss
 
 from .data_leakage import permute_tails
@@ -42,7 +41,7 @@ from .evaluators import LinkPredictionEvaluator, TripletClassificationEvaluator
 from .inference import NodeInference, EdgeInference
 from .knowledgegraph import KnowledgeGraph
 from .preprocessing import prepare_knowledge_graph, SUPPORTED_SEPARATORS
-from .samplers import PositionalNegativeSampler, BernoulliNegativeSampler, UniformNegativeSampler, MixedNegativeSampler
+from .samplers import NegativeSampler, PositionalNegativeSampler, BernoulliNegativeSampler, UniformNegativeSampler, MixedNegativeSampler
 from .utils import parse_config, load_knowledge_graph, set_random_seeds, find_best_model, merge_kg, initialize_embedding, plot_learning_curves, save_config
 
 
@@ -232,7 +231,7 @@ class Architect(Module):
         self.decoder: BilinearDecoder | ConvolutionalDecoder | TranslationalDecoder = None
         self.decoder_loss: MarginLoss | BinaryCrossEntropyLoss = None
         self.optimizer: optim.Optimizer = None
-        self.sampler: sampling.NegativeSampler = None
+        self.sampler: NegativeSampler = None
         self.scheduler: learning_rate_scheduler.LRScheduler | None = None
         self.evaluator: LinkPredictionEvaluator | TripletClassificationEvaluator = None
         self.node_embeddings: nn.ParameterList
@@ -478,7 +477,7 @@ class Architect(Module):
         return optimizer
 
 
-    def initialize_negative_sampler(self) -> sampling.NegativeSampler:
+    def initialize_negative_sampler(self) -> NegativeSampler:
         """
         Initialize the sampler according to the configuration.
         

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -292,7 +292,7 @@ class Architect(Module):
 
         Arguments
         ---------
-        encoder_name: {"Default", "GCN", "GAT", "Node2vec"}, optional
+        encoder_name: {"Default", "GCN", "GAT", "Node2Vec"}, optional
             Name of the encoder.
         gnn_layers: int, optional, default to 0
             Number of hidden layers for the encoder. Only used for deep learning encoders.
@@ -323,7 +323,7 @@ class Architect(Module):
                 encoder = GCNEncoder(edge_types, self.encoder_node_embedding_dimensions, gnn_layers)
             case "GAT":
                 encoder = GATEncoder(edge_types, self.encoder_node_embedding_dimensions, gnn_layers)
-            case "Node2vec":
+            case "Node2Vec":
                 encoder = Node2VecEncoder(self.kg_train.edge_list, self.encoder_node_embedding_dimensions, device = self.device, **encoder_config["params"])
             case _:
                 encoder = DefaultEncoder()

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -122,7 +122,6 @@ class Architect(Model):
         TODO.What_that_variable_is_or_does
     scheduler: learning_rate_scheduler.LRScheduler or None
         TODO.What_that_variable_is_or_does
-    TODO.inherited_attributes
     
     Raises
     ------

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -127,6 +127,7 @@ class Architect(Module):
     ------
     ValueError
         If the `config.metadata_csv` file exists but cannot be parsed, or if `kg` is given, but not a tuple of KnowledgeGraph and `config.run_kg_preprocessing` is set to false.
+    TODO.missing_errors
 
     Examples
     --------
@@ -302,7 +303,7 @@ class Architect(Module):
 
         Returns
         -------
-        encoder: DefaultEncoder or GCNEncoder or GATEncoder
+        encoder: DefaultEncoder or GCNEncoder or GATEncoder or Node2VecEncoder
             The encoder object.
         
         """
@@ -492,7 +493,7 @@ class Architect(Module):
 
         Returns
         -------
-        negative_sampler: torchkge.sampling.NegativeSampler TODO.NegativeSampler_super_class_maybe
+        negative_sampler: NegativeSampler TODO.NegativeSampler_super_class_maybe
             The initialized sampler.
         
         """
@@ -825,7 +826,7 @@ class Architect(Module):
             Arguments
             ---------
             engine: Engine
-                TODO.What_that_argument_is_or_does
+                Runner managing the training.
 
             """
             # Move models to CPU before saving
@@ -924,14 +925,14 @@ class Architect(Module):
         remaining_edges = all_edges - set(list_rel_1) - set(list_rel_2)
         remaining_edges = list(remaining_edges)
 
-        total_metrics_sum_list_1, fact_count_list_1, individual_metrics_list_1, group_metrics_list_1 = self.calculate_metrics_for_relations(
+        total_metrics_sum_list_1, triplet_count_list_1, individual_metrics_list_1, group_metrics_list_1 = self.calculate_metrics_for_relations(
             self.kg_test, list_rel_1)
-        total_metrics_sum_list_2, fact_count_list_2, individual_metrics_list_2, group_metrics_list_2 = self.calculate_metrics_for_relations(
+        total_metrics_sum_list_2, triplet_count_list_2, individual_metrics_list_2, group_metrics_list_2 = self.calculate_metrics_for_relations(
             self.kg_test, list_rel_2)
-        total_metrics_sum_remaining, fact_count_remaining, individual_metrics_remaining, group_metrics_remaining = self.calculate_metrics_for_relations(
+        total_metrics_sum_remaining, triplet_count_remaining, individual_metrics_remaining, group_metrics_remaining = self.calculate_metrics_for_relations(
             self.kg_test, remaining_edges)
 
-        global_metrics = (total_metrics_sum_list_1 + total_metrics_sum_list_2 + total_metrics_sum_remaining) / (fact_count_list_1 + fact_count_list_2 + fact_count_remaining)
+        global_metrics = (total_metrics_sum_list_1 + total_metrics_sum_list_2 + total_metrics_sum_remaining) / (triplet_count_list_1 + triplet_count_list_2 + triplet_count_remaining)
 
         logging.info(f"Final Test metrics with best model: {global_metrics}")
 
@@ -1106,7 +1107,7 @@ class Architect(Module):
 
         Raises
         ------
-        TODO.error_1
+        Error
             No best model was found in the checkpoint directory.
             Make sure to run the training first and not rename checkpoint files before running evaluation.
         
@@ -1194,8 +1195,8 @@ class Architect(Module):
 
         Returns
         -------
-        TODO.result_name: torch.types.Number
-            TODO.What_that_variable_is_or_does
+        loss_value: torch.types.Number
+            Training loss value of the model for this epoch.
             
         """
         batch = batch.T.to(self.device)
@@ -1249,7 +1250,7 @@ class Architect(Module):
         
         if isinstance(self.encoder, GNN):
             seed_nodes = batch[:2].unique()
-            hop_count = self.encoder.n_layers
+            hop_count = self.encoder.layer_count
             edge_list = kg.edge_list
             
             _,_,_, edge_mask = k_hop_subgraph(
@@ -1304,7 +1305,7 @@ class Architect(Module):
             input = self.kg_train.get_encoder_input(self.kg_train.graphindices.to(self.device), self.node_embeddings)
 
             encoder_output: Dict[str, Tensor] = self.encoder(input.x_dict, input.edge_list)
-            node_embeddings: torch.Tensor = torch.zeros((self.n_ent, self.encoder_node_embedding_dimensions),
+            node_embeddings: torch.Tensor = torch.zeros((self.node_count, self.encoder_node_embedding_dimensions),
                                                         device = self.device,
                                                         dtype = torch.float)
 
@@ -1345,7 +1346,7 @@ class Architect(Module):
             assert len(normalized_embeddings) == 2, "The decoder.normalize_params method should return exactly two elements, the node embedding and the edge embedding."
             self.node_embeddings, self.edge_embeddings = normalized_embeddings
             
-        logging.debug(f"Normalized all embeddings")
+        logging.debug(f"Normalized all embeddings.")
 
 
     def log_metrics_to_csv(self, engine: Engine):
@@ -1355,7 +1356,7 @@ class Architect(Module):
         Arguments
         ---------
         engine: Engine
-            TODO.What_that_argument_is_or_does
+            Runner managing the training.
             
         """
         epoch = engine.state.epoch
@@ -1391,7 +1392,7 @@ class Architect(Module):
         Arguments
         ---------
         engine: Engine
-            TODO.What_that_argument_is_or_does
+            Runner managing the training.
             
         """
         logging.info(f"Evaluating on validation set at epoch {engine.state.epoch}...")
@@ -1428,7 +1429,7 @@ class Architect(Module):
         Arguments
         ---------
         engine: Engine
-            TODO.What_that_argument_is_or_does
+            Runner managing the training.
 
         Returns
         -------
@@ -1447,7 +1448,7 @@ class Architect(Module):
         Arguments
         ---------
         engine: Engine
-            TODO.What_that_argument_is_or_does
+            Runner managing the training.
         
         """
         logging.info(f"Training completed after {engine.state.epoch} epochs.")

--- a/src/kgate/data_leakage.py
+++ b/src/kgate/data_leakage.py
@@ -17,7 +17,7 @@ def permute_tails(kg: KnowledgeGraph,
     Arguments
     ---------
     kg: KnowledgeGraph
-        The KnowledgeGraph instance on which to perform the permutation.
+        Knowledge graph on which the permutation will be done.
     edge_name: str
         The name of the edge for which `tails` should be permuted.
     preserve_node_degree: bool, optional, default to True
@@ -25,10 +25,10 @@ def permute_tails(kg: KnowledgeGraph,
 
     Raises
     ------
-    error_name
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-    error_name
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    AssertionError #1
+        The tails node degree is not conserved after permutation.
+    AssertionError #2
+        Self-loops introduced after permutation.
     
     Returns
     -------

--- a/src/kgate/data_leakage.py
+++ b/src/kgate/data_leakage.py
@@ -1,8 +1,10 @@
 import random
 from collections import Counter
+
 import torch
 
 from .knowledgegraph import KnowledgeGraph
+
 
 def permute_tails(kg: KnowledgeGraph,
                 edge_name: str,
@@ -12,19 +14,27 @@ def permute_tails(kg: KnowledgeGraph,
     Randomly permutes the `tails` for a given edge while maintaining the original degree
     of `heads` and `tails`, ensuring there are no triplets of the form (a, edge, a) where `head == tail`.
 
-    Parameters
-    ----------
+    Arguments
+    ---------
     kg: KnowledgeGraph
         The KnowledgeGraph instance on which to perform the permutation.
     edge_name: str
         The name of the edge for which `tails` should be permuted.
-    preserve_node_degree: bool, optional
-        Whether or not the permuted tails should keep the same node degree. Default to True.
-        
+    preserve_node_degree: bool, optional, default to True
+        Whether or not the permuted tails should keep the same node degree.
+
+    Raises
+    ------
+    error_name
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    error_name
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    
     Returns
     -------
     KnowledgeGraph
         A new instance of KnowledgeGraph with the `tails` permuted.
+    
     """
     node_types = kg.node_types
     triplets_types = kg.triplet_types
@@ -39,7 +49,7 @@ def permute_tails(kg: KnowledgeGraph,
     heads_for_this_edge = kg.head_indices[mask].tolist()
     tails_for_this_edge = kg.tail_indices[mask].tolist()
 
-    triplets = [0] * len(tails_for_this_edge) if len(kg.node_type_to_index)==1 else []
+    triplets = [0] * len(tails_for_this_edge) if len(kg.node_type_to_index) == 1 else []
 
     # Count the occurence of each tail in the edge
     tails_count = Counter(tails_for_this_edge)
@@ -52,8 +62,6 @@ def permute_tails(kg: KnowledgeGraph,
         tail_count = len(tails_for_this_edge)
         node_count = kg.node_count
         permuted_tails = [random.randrange(node_count) for _ in range(tail_count)]
-
-
 
     # Fix self loop and correct node degree
     for i in range(len(permuted_tails)):
@@ -79,7 +87,7 @@ def permute_tails(kg: KnowledgeGraph,
                     edge_name,
                     index_to_node_type[node_types[permuted_tails[i]].item()]
                 )
-            # Add it if it doesn't already exists
+            # Add it if it doesn't already exist
             if not permuted_triplet in triplets_types:
                 triplets_types.append(permuted_triplet)
                 triplet = len(triplets_types)

--- a/src/kgate/decoders/__init__.py
+++ b/src/kgate/decoders/__init__.py
@@ -1,3 +1,3 @@
-from .translational import TransE, TransH, TransR, TransD
-from .bilinear import RESCAL, DistMult, ComplEx
-from .convolutional import ConvKB
+from .translational import TranslationalDecoder, TransE, TransH, TransR, TransD
+from .bilinear import BilinearDecoder, RESCAL, DistMult, ComplEx
+from .convolutional import ConvolutionalDecoder, ConvKB

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -20,8 +20,11 @@ from torchkge.models import DistMultModel, RESCALModel, ComplExModel
 
 from ..utils import initialize_embedding
 
+
+
 class BilinearDecoder(Module):
-    """Interface for bilinear decoders of KGATE.
+    """
+    Interface for bilinear decoders of KGATE.
 
     This interface is largely inspired by TorchKGE's BilinearModel, and exposes
     the methods that all bilinear decoders must use to be compatible with KGATE.
@@ -29,18 +32,20 @@ class BilinearDecoder(Module):
     to take care of their initialization, and only requires one attribute to be set.
 
     Furthermore, this interface doesn't implement anything but is a type helper.
+    
     """
     
-    def score(self,
-        *,
-        head_embeddings: Tensor,
-        tail_embeddings: Tensor,
-        edge_embeddings: Tensor,
-        head_indices: Tensor,
-        tail_indices: Tensor,
-        edge_indices: Tensor
-        ) -> Tensor:
-        """Interface method for the decoder's score function.
+    def score(  self,
+                *,
+                head_embeddings: Tensor,
+                tail_embeddings: Tensor,
+                edge_embeddings: Tensor,
+                head_indices: Tensor,
+                tail_indices: Tensor,
+                edge_indices: Tensor
+                ) -> Tensor:
+        """
+        Interface method for the decoder's score function.
 
         Refer to the specific decoder for details on scoring function implementation.
         While all arguments are given when called from the Architect class, most 
@@ -71,14 +76,22 @@ class BilinearDecoder(Module):
         -------
             batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
                 The score of each triplet as a tensor.
+        
         """
         raise NotImplementedError("The score method must be implemented by the bilinear decoder.")
 
+
     def normalize_parameters(self) -> Tuple[nn.ParameterList, nn.Embedding] | None:
+        """
+        TODO.docstring
+        
+        """    
         return None
 
+
     def get_embeddings(self) -> Dict[str, Tensor] | None:
-        """Get the decoder-specific embeddings.
+        """
+        Get the decoder-specific embeddings.
         
         If the decoder doesn't have dedicated embeddings, nothing is returned. In 
         this case, it is not necessary to implement this method from the interface.
@@ -87,10 +100,16 @@ class BilinearDecoder(Module):
         -------
             embeddings: Dict[str, torch.Tensor] or None
                 Decoder-specific embeddings, or None.
+        
         """
         return None
 
+
     def inference_prepare_candidates(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """
+        TODO.docstring
+        
+        """
         raise NotImplementedError("The inference_prepare_candidates method must be implemented by the bilinear decoder.")
 
 
@@ -100,9 +119,13 @@ class BilinearDecoder(Module):
                         projected_tails: Tensor,
                         edges: Tensor
                         ) -> Tensor:
-        """TODO docstring
+        """
+        TODO docstring
+        
         """
         raise NotImplementedError("Bilinear decoders must implement the inference_score function themselves.")
+
+
 
 class RESCAL(BilinearDecoder):
     """
@@ -138,6 +161,7 @@ class RESCAL(BilinearDecoder):
                 embedding_dimensions: int, 
                 node_count: int,
                 edge_count: int):
+        
         self.edge_count = edge_count
         self.node_count = node_count
         self.embedding_dimensions = embedding_dimensions
@@ -174,7 +198,6 @@ class RESCAL(BilinearDecoder):
         head_normalized_embeddings = normalize(head_embeddings, p = 2, dim = 1)
         tail_normalized_embeddings = normalize(tail_embeddings, p = 2, dim = 1)
         edge_embeddings = self.edge_embeddings_matrix(edge_indices).view(-1, self.embedding_dimensions, self.embedding_dimensions)
-        # TODO: hr = head_edge_embeddings to rename
         head_edge_embeddings = matmul(head_normalized_embeddings.view(-1, 1, self.embedding_dimensions), edge_embeddings)
         
         return (head_edge_embeddings.view(-1, self.embedding_dimensions) * tail_normalized_embeddings).sum(dim = 1)
@@ -236,7 +259,7 @@ class RESCAL(BilinearDecoder):
         """
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
-        `inference_scoring_function` method. See torchkge.models.interfaces.Models for
+        `inference_score` method. See torchkge.models.interfaces.Models for
         more details on the API.
 
         Arguments
@@ -282,10 +305,15 @@ class RESCAL(BilinearDecoder):
 
         return head_embeddings, tail_embeddings, edge_embeddings_inference, candidates
 
-    def inference_scoring_function(self, *,
-                                    head_embeddings: Tensor,
-                                    tail_embeddings: Tensor,
-                                    edge_embeddings: Tensor) -> Tensor:
+
+    def inference_score(self, *,
+                        head_embeddings: Tensor,
+                        tail_embeddings: Tensor,
+                        edge_embeddings: Tensor) -> Tensor:
+        """
+        TODO.docstring
+        
+        """        
         batch_size = head_embeddings.size(0)
 
         if len(head_embeddings.size()) == 3:
@@ -293,13 +321,17 @@ class RESCAL(BilinearDecoder):
                 "When inferring heads, ..."
 
             tail_edge_embeddings = matmul(edge_embeddings, tail_embeddings.view(batch_size, self.embedding_dimensions, 1)).view(batch_size, 1, self.embedding_dimensions)
-            return (head_embeddings * tail_edge_embeddings).sum(dim=2)
+            
+            return (head_embeddings * tail_edge_embeddings).sum(dim = 2)
+        
         elif len(tail_embeddings.size()) == 3:
             assert (len(head_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 3), \
                 "When inferring tails, ..."
             
             head_edge_embeddings = matmul(head_embeddings.view(batch_size, 1, self.embedding_dimensions)).view(batch_size, 1, self.embedding_dimensions)
-            return (head_edge_embeddings * tail_embeddings).sum(dim=2)
+            
+            return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
+        
         elif len(edge_embeddings.size()) == 4:
             assert (len(head_embeddings.size()) == 2) and (len(tail_embeddings.size()) == 2), \
                 "When inferring edges, ..."
@@ -307,7 +339,10 @@ class RESCAL(BilinearDecoder):
             head_embeddings = head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions)
             tail_embeddings = tail_embeddings.view(batch_size, 1, self.embedding_dimensions)
             head_edge_embeddings = matmul(head_embeddings, edge_embeddings).view(batch_size, self.edge_count, self.embedding_dimensions)
-            return (head_edge_embeddings * tail_embeddings).sum(dim=2)
+            
+            return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
+    
+    
     
 class DistMult(BilinearDecoder):
     """
@@ -414,7 +449,7 @@ class DistMult(BilinearDecoder):
         """
         Link prediction evaluation helper function. Get node embeddings
         and relations embeddings. The output will be fed to the
-        `inference_scoring_function` method.
+        `inference_score_function` method.
 
         Arguments
         ---------
@@ -461,6 +496,7 @@ class DistMult(BilinearDecoder):
         
         return head_embeddings, tail_embeddings, edge_embeddings_inference, candidates
 
+
     def inference_score(self, *,
                         head_embeddings: Tensor,
                         tail_embeddings: Tensor,
@@ -481,6 +517,7 @@ class DistMult(BilinearDecoder):
         -------
         score: torch.Tensor
             TODO.What_that_variable_is_or_does
+        
         """
         batch_size = head_embeddings.size(0)
 
@@ -489,19 +526,26 @@ class DistMult(BilinearDecoder):
                 "When inferring heads, ..."
 
             tail_edge_embeddings = (edge_embeddings * tail_embeddings).view(batch_size, 1, self.embedding_dimensions)
-            return (head_embeddings * tail_edge_embeddings).sum(dim=2)
+            
+            return (head_embeddings * tail_edge_embeddings).sum(dim = 2)
+        
         elif len(tail_embeddings.size()) == 3:
             assert (len(head_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 2), \
                 "When inferring tails, ..."
             
             head_edge_embeddings = (head_embeddings * edge_embeddings).view(batch_size, 1, self.embedding_dimensions)
-            return (head_edge_embeddings * tail_embeddings).sum(dim=2)
+            
+            return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
+        
         elif len(edge_embeddings.size()) == 3:
             assert (len(head_embeddings.size()) == 2) and (len(tail_embeddings.size()) == 2), \
                 "When inferring edges, ..."
 
             head_edge_embeddings = (head_embeddings.view(batch_size, 1, self.embedding_dimensions) * edge_embeddings)
-            return (head_edge_embeddings * tail_embeddings.view(batch_size, 1, self.embedding_dimensions)).sum(dim=2)
+            
+            return (head_edge_embeddings * tail_embeddings.view(batch_size, 1, self.embedding_dimensions)).sum(dim = 2)
+
+
 
 class ComplEx(BilinearDecoder):
     """
@@ -531,11 +575,12 @@ class ComplEx(BilinearDecoder):
         self.embedding_spaces = 2
 
 
-    def score(self, *,
-            head_embeddings: Tensor,
-            tail_embeddings: Tensor,
-            edge_embeddings: Tensor,
-            **_):
+    def score(  self,
+                *,
+                head_embeddings: Tensor,
+                tail_embeddings: Tensor,
+                edge_embeddings: Tensor,
+                **_):
         """
         TODO.What_the_function_does_about_globally
 
@@ -555,15 +600,16 @@ class ComplEx(BilinearDecoder):
             TODO.What_that_variable_is_or_does
         
         """        
-        real_head_embedddings, imaginary_head_embeddings = tensor_split(head_embeddings, 2, dim=1)
-        real_tail_embedddings, imaginary_tail_embeddings = tensor_split(tail_embeddings, 2, dim=1)
-        real_edge_embedddings, imaginary_edge_embeddings = tensor_split(edge_embeddings, 2, dim=1)
+        real_head_embedddings, imaginary_head_embeddings = tensor_split(head_embeddings, 2, dim = 1)
+        real_tail_embedddings, imaginary_tail_embeddings = tensor_split(tail_embeddings, 2, dim = 1)
+        real_edge_embedddings, imaginary_edge_embeddings = tensor_split(edge_embeddings, 2, dim = 1)
         
         return (real_head_embedddings * (real_edge_embedddings * real_tail_embedddings + imaginary_edge_embeddings * imaginary_tail_embeddings) + 
-                imaginary_head_embeddings * (real_edge_embedddings * imaginary_tail_embeddings - imaginary_edge_embeddings * real_tail_embedddings)).sum(dim=1)
+                imaginary_head_embeddings * (real_edge_embedddings * imaginary_tail_embeddings - imaginary_edge_embeddings * real_tail_embedddings)).sum(dim = 1)
     
     
-    def inference_prepare_candidates(self, *, 
+    def inference_prepare_candidates(self,
+                                    *, 
                                     head_indices: Tensor, 
                                     tail_indices: Tensor, 
                                     edge_indices: Tensor, 
@@ -611,14 +657,14 @@ class ComplEx(BilinearDecoder):
         """
         batch_size = head_indices.shape[0]
 
-        real_head_embeddings, imaginary_head_embeddings = tensor_split(node_embeddings[head_indices], 2, dim=1)
-        real_tail_embeddings, imaginary_tail_embeddings = tensor_split(node_embeddings[tail_indices], 2, dim=1)
-        real_edge_embeddings, imaginary_edge_embeddings = tensor_split(edge_embeddings(edge_indices), 2, dim=1)
+        real_head_embeddings, imaginary_head_embeddings = tensor_split(node_embeddings[head_indices], 2, dim = 1)
+        real_tail_embeddings, imaginary_tail_embeddings = tensor_split(node_embeddings[tail_indices], 2, dim = 1)
+        real_edge_embeddings, imaginary_edge_embeddings = tensor_split(edge_embeddings(edge_indices), 2, dim = 1)
 
         if node_inference:
-            real_candidates, imaginary_candidates = tensor_split(node_embeddings, 2, dim=1)
+            real_candidates, imaginary_candidates = tensor_split(node_embeddings, 2, dim = 1)
         else:
-            real_candidates, imaginary_candidates = tensor_split(edge_embeddings, 2, dim=1)
+            real_candidates, imaginary_candidates = tensor_split(edge_embeddings, 2, dim = 1)
         
         real_candidates = real_candidates.unsqueeze(0).expand(batch_size, -1, -1)
         imaginary_candidates = imaginary_candidates.unsqueeze(0).expand(batch_size, -1, -1)
@@ -628,14 +674,19 @@ class ComplEx(BilinearDecoder):
                 (real_edge_embeddings, imaginary_edge_embeddings), \
                 (real_candidates, imaginary_candidates)
     
-    def inference_score(self, *,
+    
+    def inference_score(self,
+                        *,
                         head_embeddings: Tensor,
                         tail_embeddings: Tensor,
                         edge_embeddings: Tensor):
-
-        real_head_embeddings, imaginary_head_embeddings = tensor_split(head_embeddings, 2, dim=1)
-        real_tail_embeddings, imaginary_tail_embeddings = tensor_split(tail_embeddings, 2, dim=1)
-        real_edge_embeddings, imaginary_edge_embeddings = tensor_split(edge_embeddings, 2, dim=1)
+        """
+        TODO.docstring
+        
+        """
+        real_head_embeddings, imaginary_head_embeddings = tensor_split(head_embeddings, 2, dim = 1)
+        real_tail_embeddings, imaginary_tail_embeddings = tensor_split(tail_embeddings, 2, dim = 1)
+        real_edge_embeddings, imaginary_edge_embeddings = tensor_split(edge_embeddings, 2, dim = 1)
         
         batch_size = real_head_embeddings.size(0)
 
@@ -646,12 +697,12 @@ class ComplEx(BilinearDecoder):
             return (real_head_embeddings * 
                         (real_edge_embeddings * real_tail_embeddings 
                          + imaginary_edge_embeddings * imaginary_tail_embeddings
-                         ).view(batch_size, 1, self.embedding_dimensions)
+                        ).view(batch_size, 1, self.embedding_dimensions)
                     + imaginary_head_embeddings * 
                         (real_edge_embeddings * imaginary_tail_embeddings
                         - imaginary_edge_embeddings * real_tail_embeddings
                         ).view(batch_size, 1, self.embedding_spaces)
-                    ).sum(dim=2)
+                    ).sum(dim = 2)
 
         elif len(real_tail_embeddings.size()) == 3:
             assert (len(real_head_embeddings.size()) == 2) and (len(real_edge_embeddings.size()) == 2), \
@@ -659,11 +710,11 @@ class ComplEx(BilinearDecoder):
             
             return ((real_head_embeddings * real_edge_embeddings
                         - imaginary_head_embeddings * imaginary_edge_embeddings
-                    ).view(batch_size, 1, self.embedding_dimensions)
+                        ).view(batch_size, 1, self.embedding_dimensions)
                     * real_tail_embeddings
                     + (real_head_embeddings * imaginary_edge_embeddings
-                       + imaginary_head_embeddings * real_tail_embeddings
-                       ).view(batch_size, 1, self.embedding_dimensions)
+                        + imaginary_head_embeddings * real_tail_embeddings
+                        ).view(batch_size, 1, self.embedding_dimensions)
                     * imaginary_tail_embeddings
                     )
 
@@ -672,12 +723,12 @@ class ComplEx(BilinearDecoder):
                 "When inferring edges, ..."
             
             return ((real_head_embeddings * real_tail_embeddings
-                     + imaginary_head_embeddings * imaginary_tail_embeddings
-                     ).view(batch_size, 1, self.embedding_dimensions)
-                     * real_edge_embeddings
-                     + (real_head_embeddings * imaginary_tail_embeddings
+                        + imaginary_head_embeddings * imaginary_tail_embeddings
+                        ).view(batch_size, 1, self.embedding_dimensions)
+                    * real_edge_embeddings
+                    + (real_head_embeddings * imaginary_tail_embeddings
                         - imaginary_head_embeddings * real_tail_embeddings
-                     ).view(batch_size, 1, self.embedding_dimensions)
-                     * imaginary_edge_embeddings
-                    ).sum(dim=2)
+                        ).view(batch_size, 1, self.embedding_dimensions)
+                    * imaginary_edge_embeddings
+                    ).sum(dim = 2)
                     

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -52,6 +52,7 @@ class RESCAL(RESCALModel):
                 embedding_dimensions: int, 
                 node_count: int,
                 edge_count: int):
+        
         super().__init__(embedding_dimensions, node_count, edge_count)
         del self.ent_emb
         self.edge_embeddings_matrix = initialize_embedding(self.n_rel, self.emb_dim * self.emb_dim)
@@ -222,6 +223,7 @@ class DistMult(DistMultModel):
                 embedding_dimensions: int,
                 node_count: int,
                 edge_count: int):
+        
         super().__init__(embedding_dimensions, node_count, edge_count)
         del self.ent_emb
         del self.rel_emb
@@ -372,11 +374,11 @@ class ComplEx(ComplExModel):
     TODO.inherited_attributes
     
     """
-    
     def __init__(self,
                 embedding_dimensions: int,
                 node_count: int,
                 edge_count: int):
+        
         super().__init__(embedding_dimensions, node_count, edge_count)
         self.embedding_spaces = 2
         del self.re_ent_emb

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -69,11 +69,11 @@ class RESCAL(RESCALModel):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             Indices of edges in the knowledge graph.
         TODO.kwargs
 
@@ -153,17 +153,17 @@ class RESCAL(RESCALModel):
 
         Arguments
         ---------
-        head_indices: torch.Tensor
+        head_indices: torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices: torch.Tensor
+        tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the relations (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             Unused.
-        node_inference: bool, default to True
+        node_inference: bool, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -238,11 +238,11 @@ class DistMult(DistMultModel):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             Unused
         TODO.kwargs
 
@@ -305,17 +305,17 @@ class DistMult(DistMultModel):
 
         Arguments
         ---------
-        head_indices: torch.Tensor
+        head_indices: torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices: torch.Tensor
+        tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the relations (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference: bool, default to True
+        node_inference: bool, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -395,11 +395,11 @@ class ComplEx(ComplExModel):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             Indices of edges in the knowledge graph.
         TODO.kwargs
 
@@ -450,17 +450,17 @@ class ComplEx(ComplExModel):
 
         Arguments
         ---------
-        head_indices: torch.Tensor
+        head_indices: torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices: torch.Tensor
+        tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the relations (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference: bool, default to True
+        node_inference: bool, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -53,28 +53,28 @@ class BilinearDecoder(Module):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        head_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the head entities for the current batch of length `batch_size`
             (or the whole graph, if it fits in memory)
-        tail_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        tail_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        edge_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        head_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        head_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the head entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        tail_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        tail_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        edge_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
 
         Returns
         -------
-            batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
+            batch_score: torch.Tensor, dtype: torch.float, shape: [batch_size]
                 The score of each triplet as a tensor.
         
         """

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -505,7 +505,8 @@ class RESCAL(BilinearDecoder):
         
             return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
         
-        # TODO: else with raise error
+        else:
+            raise ValueError("None of the embeddings have a shape adapted to be inferred. Shapes must be: 3 for `head_embeddings` and `tail_embeddings`, and 4 for `edge_embeddings`.")
     
     
     
@@ -742,7 +743,8 @@ class DistMult(BilinearDecoder):
             
             return (head_edge_embeddings * tail_embeddings.view(batch_size, 1, self.embedding_dimensions)).sum(dim = 2)
         
-        # TODO: else with raise error
+        else:
+            raise ValueError("None of the embeddings have a shape adapted to be inferred. Shapes must be of 3 for `head_embeddings`, `tail_embeddings` and `edge_embeddings`.")
 
 
 
@@ -963,4 +965,6 @@ class ComplEx(BilinearDecoder):
                     * imaginary_edge_embeddings
                     ).sum(dim = 2)
         
-        # TODO: else with raise error
+        else:
+            raise ValueError("None of the embeddings have a shape adapted to be inferred. Shapes must be of 3 for `head_embeddings`, `tail_embeddings` and `edge_embeddings`.")
+    

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -46,7 +46,7 @@ class BilinearDecoder(Module):
         """
         Interface method for the decoder's score function.
 
-        Refer to the specific decoder for details on scoring function implementation.
+        Refer to the specific decoder for details on this function's implementation.
         While all arguments are given when called from the Architect class, most 
         decoders only use some of them. 
 
@@ -125,6 +125,8 @@ class BilinearDecoder(Module):
         """
         Get the decoder-specific embeddings.
         
+        Refer to the specific decoder for details on this function's implementation.
+        
         Returns
         -------
         edge_embeddings_matrix: Dict[str, torch.Tensor] or None
@@ -160,6 +162,10 @@ class BilinearDecoder(Module):
         and edge embeddings. The output will be fed to the
         `inference_score_function` method.
         
+        Refer to the specific decoder for details on this function's implementation.
+        While all arguments are given when called from the Architect class, most 
+        decoders only use some of them.
+        
         Arguments
         ---------
         head_indices: torch.Tensor, keyword-only
@@ -175,6 +181,12 @@ class BilinearDecoder(Module):
         node_inference: bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
         
+        Raises
+        ------
+        NotImplementedError
+            The inference_prepare_candidates method must be implemented by a bilinear decoder
+            inheriting from this interface.
+        
         Returns
         -------
         head_embeddings: torch.Tensor or Tuple
@@ -185,12 +197,6 @@ class BilinearDecoder(Module):
             Edge embeddings.
         candidates: torch.Tensor or Tuple
             Candidate embeddings for nodes or edges.
-        
-        Raises
-        ------
-        NotImplementedError
-            The inference_prepare_candidates method must be implemented by a bilinear decoder
-            inheriting from this interface.
         
         """
         raise NotImplementedError("The inference_prepare_candidates method must be implemented by the bilinear decoder.")
@@ -204,6 +210,10 @@ class BilinearDecoder(Module):
                         ) -> Tensor:
         """
         TODO.what_that_function_does
+
+        Refer to the specific decoder for details on this function's implementation.
+        While all arguments are given when called from the Architect class, most 
+        decoders only use some of them.
         
         Arguments
         ---------

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -105,15 +105,17 @@ class BilinearDecoder(Module):
         
         Returns
         -------
-        node_embeddings : torch.nn.ParameterList
+        node_embeddings: torch.nn.ParameterList
             The normalized node embedding object.
-        edge_embeddings_emb : torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding
             The normalized edges embedding object.
         
         Notes
         -----
         The normalize_parameters method can be implemented by a bilinear decoder inheriting from this class
         if it has specific parameters to normalize.
+        If the decoder doesn't have dedicated normalization, nothing is returned. In 
+        this case, it is not necessary to implement this method from the interface.
         
         """    
         return None
@@ -122,9 +124,6 @@ class BilinearDecoder(Module):
     def get_embeddings(self) -> Dict[str, Tensor] | None:
         """
         Get the decoder-specific embeddings.
-        
-        If the decoder doesn't have dedicated embeddings, nothing is returned. In 
-        this case, it is not necessary to implement this method from the interface.
         
         Returns
         -------
@@ -135,6 +134,8 @@ class BilinearDecoder(Module):
         -----
         The get_embeddings method can be implemented by a bilinear decoder inheriting from this class
         if it needed.
+        If the decoder doesn't have dedicated embeddings, nothing is returned. In 
+        this case, it is not necessary to implement this method from the interface.
         
         """
         return None
@@ -155,7 +156,9 @@ class BilinearDecoder(Module):
                                                 Tensor | Tuple
                                                 ]:
         """
-        TODO
+        Link prediction evaluation helper function. Get node embeddings
+        and edge embeddings. The output will be fed to the
+        `inference_score_function` method.
         
         Arguments
         ---------
@@ -164,7 +167,7 @@ class BilinearDecoder(Module):
         tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
         edge_indices: torch.Tensor, keyword-only
-            The indices of the relations (from KG).
+            The indices of the edges (from KG).
         node_embeddings: torch.Tensor, shape: [node_count, node_embedding_dimensions], keyword-only
             Embeddings of all nodes.
         edge_embeddings: torch.nn.Embedding, keyword-only
@@ -200,7 +203,7 @@ class BilinearDecoder(Module):
                         edge_embeddings: Tensor
                         ) -> Tensor:
         """
-        TODO.what_that_funciton_does
+        TODO.what_that_function_does
         
         Arguments
         ---------
@@ -336,9 +339,9 @@ class RESCAL(BilinearDecoder):
         
         Returns
         -------
-        node_embeddings : torch.nn.ParameterList
+        node_embeddings: torch.nn.ParameterList
             The normalized node embedding object.
-        edge_embeddings : torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding
             The unchanged edges embedding object.
         
         """
@@ -358,7 +361,7 @@ class RESCAL(BilinearDecoder):
             TODO.What_that_variable_is_or_does
             
         """
-        return {"edge_embeddings_matrix" : self.edge_embeddings_matrix.weight.data.view(-1, self.embedding_dimensions, self.embedding_dimensions)}
+        return {"edge_embeddings_matrix": self.edge_embeddings_matrix.weight.data.view(-1, self.embedding_dimensions, self.embedding_dimensions)}
     
 
     def inference_prepare_candidates(self,
@@ -373,8 +376,7 @@ class RESCAL(BilinearDecoder):
         """
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
-        `inference_score` method. See torchkge.models.interfaces.Models for
-        more details on the API.
+        `inference_score_function` method.
 
         Arguments
         ---------
@@ -383,7 +385,7 @@ class RESCAL(BilinearDecoder):
         tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
         edge_indices: torch.Tensor, keyword-only
-            The indices of the relations (from KG).
+            The indices of the edges (from KG).
         node_embeddings: torch.Tensor, shape: [node_count, node_embedding_dimensions], keyword-only
             Embeddings of all nodes.
         edge_embeddings: torch.nn.Embedding, keyword-only
@@ -593,9 +595,9 @@ class DistMult(BilinearDecoder):
         
         Returns
         -------
-        node_embeddings : torch.nn.ParameterList
+        node_embeddings: torch.nn.ParameterList
             The normalized node embedding object.
-        edge_embeddings : torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding
             The unchanged edges embedding object.
         
         """
@@ -616,9 +618,8 @@ class DistMult(BilinearDecoder):
                                     ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         Link prediction evaluation helper function. Get node embeddings
-        and relations embeddings. The output will be fed to the
+        and edge embeddings. The output will be fed to the
         `inference_score_function` method.
-
         Arguments
         ---------
         head_indices: torch.Tensor, keyword-only
@@ -626,7 +627,7 @@ class DistMult(BilinearDecoder):
         tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
         edge_indices: torch.Tensor, keyword-only
-            The indices of the relations (from KG).
+            The indices of the edges (from KG).
         node_embeddings: torch.Tensor, shape: [node_count, node_embedding_dimensions], keyword-only
             Embeddings of all nodes.
         edge_embeddings: torch.nn.Embedding, keyword-only
@@ -648,16 +649,16 @@ class DistMult(BilinearDecoder):
         """
         batch_size = head_indices.shape[0]
 
-        # Get head, tail and relation embeddings
+        # Get head, tail and edge embeddings
         head_embeddings = node_embeddings[head_indices]
         tail_embeddings = node_embeddings[tail_indices]
         edge_embeddings_inference = edge_embeddings(edge_indices)
         
         if node_inference:
-            # Prepare candidates for every entities
+            # Prepare candidates for every node
             candidates = node_embeddings
         else:
-            # Prepare candidates for every relations
+            # Prepare candidates for every edge
             candidates = edge_embeddings.weight.data
         
         candidates = candidates.unsqueeze(0).expand(batch_size, -1, -1)
@@ -813,7 +814,9 @@ class ComplEx(BilinearDecoder):
                                         Tuple[Tensor, Tensor],
                                         Tuple[Tensor, Tensor]]:
         """
-        TODO.What_the_class_is_about_globally
+        Link prediction evaluation helper function. Get node embeddings
+        and edge embeddings. The output will be fed to the
+        `inference_score_function` method.
 
         References
         ----------
@@ -826,7 +829,7 @@ class ComplEx(BilinearDecoder):
         tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
         edge_indices: torch.Tensor, keyword-only
-            The indices of the relations (from KG).
+            The indices of the edges (from KG).
         node_embeddings: torch.Tensor, shape: [node_count, node_embedding_dimensions], keyword-only
             Embeddings of all nodes.
         edge_embeddings: torch.nn.Embedding, keyword-only

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -24,7 +24,7 @@ class BilinearDecoder(Module):
     """Interface for bilinear decoders of KGATE.
 
     This interface is largely inspired by TorchKGE's BilinearModel, and exposes
-    the methods that all translational decoders must use to be compatible with KGATE.
+    the methods that all bilinear decoders must use to be compatible with KGATE.
     The interface doesn't have an __init__ method as inheriting decoders are supposed
     to take care of their initialization, and only requires one attribute to be set.
 
@@ -74,10 +74,10 @@ class BilinearDecoder(Module):
         """
         raise NotImplementedError("The score method must be implemented by the bilinear decoder.")
 
-    def normalize_parameters(self):
-        pass
+    def normalize_parameters(self) -> Tuple[nn.ParameterList, nn.Embedding] | None:
+        return None
 
-    def get_embeddings(self) -> Dict[str, Tensor] |None:
+    def get_embeddings(self) -> Dict[str, Tensor] | None:
         """Get the decoder-specific embeddings.
         
         If the decoder doesn't have dedicated embeddings, nothing is returned. In 
@@ -90,15 +90,16 @@ class BilinearDecoder(Module):
         """
         return None
 
-    def inference_prepare_candidates(self):
-        pass
+    def inference_prepare_candidates(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        raise NotImplementedError("The inference_prepare_candidates method must be implemented by the bilinear decoder.")
+
 
     def inference_score(self, 
                         *,
                         projected_heads: Tensor,
                         projected_tails: Tensor,
                         edges: Tensor
-                        ):
+                        ) -> Tensor:
         """TODO docstring
         """
         raise NotImplementedError("Bilinear decoders must implement the inference_score function themselves.")

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -314,26 +314,26 @@ class RESCAL(BilinearDecoder):
         TODO.docstring
         
         """        
-        batch_size = head_embeddings.size(0)
+        batch_size = head_embeddings.shape[0]
 
-        if len(head_embeddings.size()) == 3:
-            assert (len(tail_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 3), \
+        if len(head_embeddings.shape) == 3:
+            assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 3), \
                 "When inferring heads, ..."
 
             tail_edge_embeddings = matmul(edge_embeddings, tail_embeddings.view(batch_size, self.embedding_dimensions, 1)).view(batch_size, 1, self.embedding_dimensions)
             
             return (head_embeddings * tail_edge_embeddings).sum(dim = 2)
         
-        elif len(tail_embeddings.size()) == 3:
-            assert (len(head_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 3), \
+        elif len(tail_embeddings.shape) == 3:
+            assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 3), \
                 "When inferring tails, ..."
             
             head_edge_embeddings = matmul(head_embeddings.view(batch_size, 1, self.embedding_dimensions)).view(batch_size, 1, self.embedding_dimensions)
             
             return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
         
-        elif len(edge_embeddings.size()) == 4:
-            assert (len(head_embeddings.size()) == 2) and (len(tail_embeddings.size()) == 2), \
+        elif len(edge_embeddings.shape) == 4:
+            assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
                 "When inferring edges, ..."
 
             head_embeddings = head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions)
@@ -519,26 +519,26 @@ class DistMult(BilinearDecoder):
             TODO.What_that_variable_is_or_does
         
         """
-        batch_size = head_embeddings.size(0)
+        batch_size = head_embeddings.shape[0]
 
-        if len(head_embeddings.size()) == 3:
-            assert (len(tail_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 2), \
+        if len(head_embeddings.shape) == 3:
+            assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
                 "When inferring heads, ..."
 
             tail_edge_embeddings = (edge_embeddings * tail_embeddings).view(batch_size, 1, self.embedding_dimensions)
             
             return (head_embeddings * tail_edge_embeddings).sum(dim = 2)
         
-        elif len(tail_embeddings.size()) == 3:
-            assert (len(head_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 2), \
+        elif len(tail_embeddings.shape) == 3:
+            assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
                 "When inferring tails, ..."
             
             head_edge_embeddings = (head_embeddings * edge_embeddings).view(batch_size, 1, self.embedding_dimensions)
             
             return (head_edge_embeddings * tail_embeddings).sum(dim = 2)
         
-        elif len(edge_embeddings.size()) == 3:
-            assert (len(head_embeddings.size()) == 2) and (len(tail_embeddings.size()) == 2), \
+        elif len(edge_embeddings.shape) == 3:
+            assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
                 "When inferring edges, ..."
 
             head_edge_embeddings = (head_embeddings.view(batch_size, 1, self.embedding_dimensions) * edge_embeddings)
@@ -688,10 +688,10 @@ class ComplEx(BilinearDecoder):
         real_tail_embeddings, imaginary_tail_embeddings = tensor_split(tail_embeddings, 2, dim = 1)
         real_edge_embeddings, imaginary_edge_embeddings = tensor_split(edge_embeddings, 2, dim = 1)
         
-        batch_size = real_head_embeddings.size(0)
+        batch_size = real_head_embeddings.shape[0]
 
-        if len(real_head_embeddings.size()) == 3:
-            assert (len(real_tail_embeddings.size()) == 2) and (len(real_edge_embeddings.size()) == 2), \
+        if len(real_head_embeddings.shape) == 3:
+            assert (len(real_tail_embeddings.shape) == 2) and (len(real_edge_embeddings.shape) == 2), \
                 "When inferring heads, ..."
             
             return (real_head_embeddings * 
@@ -704,8 +704,8 @@ class ComplEx(BilinearDecoder):
                         ).view(batch_size, 1, self.embedding_spaces)
                     ).sum(dim = 2)
 
-        elif len(real_tail_embeddings.size()) == 3:
-            assert (len(real_head_embeddings.size()) == 2) and (len(real_edge_embeddings.size()) == 2), \
+        elif len(real_tail_embeddings.shape) == 3:
+            assert (len(real_head_embeddings.shape) == 2) and (len(real_edge_embeddings.shape) == 2), \
                 "When inferring tails, ..."
             
             return ((real_head_embeddings * real_edge_embeddings
@@ -718,8 +718,8 @@ class ComplEx(BilinearDecoder):
                     * imaginary_tail_embeddings
                     )
 
-        elif len(real_edge_embeddings.size()) == 3:
-            assert (len(real_head_embeddings.size()) == 2) and (len(real_tail_embeddings.size()) == 2), \
+        elif len(real_edge_embeddings.shape) == 3:
+            assert (len(real_head_embeddings.shape) == 2) and (len(real_tail_embeddings.shape) == 2), \
                 "When inferring edges, ..."
             
             return ((real_head_embeddings * real_tail_embeddings

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -8,6 +8,7 @@ Modifications and additional functionalities added by Benjamin Loire <benjamin.l
 - 
 
 The modifications are licensed under the BSD license according to the source license.
+
 """
 
 from typing import Tuple, Dict          
@@ -264,7 +265,7 @@ class RESCAL(BilinearDecoder):
         
     Attributes
     ----------
-    edge_embeddings_matrix: TODO.type
+    edge_embeddings_matrix: Dict[str, Tensor]
         TODO.What_that_variable_is_or_does
     embedding_dimensions: int
         Dimensions of embeddings.
@@ -630,6 +631,7 @@ class DistMult(BilinearDecoder):
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
         `inference_score_function` method.
+        
         Arguments
         ---------
         head_indices: torch.Tensor, keyword-only
@@ -827,10 +829,6 @@ class ComplEx(BilinearDecoder):
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
         `inference_score_function` method.
-
-        References
-        ----------
-        TODO
 
         Arguments
         ---------

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -106,9 +106,9 @@ class BilinearDecoder(Module):
         
         Returns
         -------
-        node_embeddings: torch.nn.ParameterList
+        node_embeddings: torch.nn.ParameterList or None
             The normalized node embedding object.
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding or None
             The normalized edges embedding object.
         
         Notes
@@ -461,6 +461,8 @@ class RESCAL(BilinearDecoder):
             and edge_embeddings must have 3 dimensions.
         AssertionError #3
             When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions.
+        ValueError
+            Raised if none of the embeddings have a shape adapted to be inferred.
 
         Returns
         -------
@@ -481,7 +483,7 @@ class RESCAL(BilinearDecoder):
 
         if len(head_embeddings.shape) == 3:
             assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 3), \
-                "When inferring heads, ..."
+                "When inferring heads, the tensors tail_embeddings must have 2 dimensions and edge_embeddings must have 3 dimensions."
 
             tail_edge_embeddings = matmul(edge_embeddings, tail_embeddings.view(batch_size, self.embedding_dimensions, 1)).view(batch_size, 1, self.embedding_dimensions)
             
@@ -489,7 +491,7 @@ class RESCAL(BilinearDecoder):
         
         elif len(tail_embeddings.shape) == 3:
             assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 3), \
-                "When inferring tails, ..."
+                "When inferring tails, the tensors head_embeddings must have 2 dimensions and edge_embeddings must have 3 dimensions."
             
             head_edge_embeddings = matmul(head_embeddings.view(batch_size, 1, self.embedding_dimensions)).view(batch_size, 1, self.embedding_dimensions)
             
@@ -497,7 +499,7 @@ class RESCAL(BilinearDecoder):
         
         elif len(edge_embeddings.shape) == 4:
             assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
-                "When inferring edges, ..."
+                "When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions."
 
             head_embeddings = head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions)
             tail_embeddings = tail_embeddings.view(batch_size, 1, self.embedding_dimensions)
@@ -529,6 +531,12 @@ class DistMult(BilinearDecoder):
 
     Attributes
     ----------
+    embedding_dimensions: int
+        Dimensions of embeddings.
+    node_count: int
+        Number of nodes in the knowledge graph.
+    edge_count: int
+        Number of edges in the knowledge graph.
     TODO.inherited_attributes
     
     """
@@ -705,6 +713,8 @@ class DistMult(BilinearDecoder):
             When inferring tails, the tensors head_embeddings and edge_embeddings must have 2 dimensions.
         AssertionError #3
             When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions.
+        ValueError
+            If none of the embeddings have a shape adapted to be inferred.
 
         Returns
         -------
@@ -721,7 +731,7 @@ class DistMult(BilinearDecoder):
 
         if len(head_embeddings.shape) == 3:
             assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
-                "When inferring heads, ..."
+                "When inferring heads, the tensors tail_embeddings and edge_embeddings must have 2 dimensions."
 
             tail_edge_embeddings = (edge_embeddings * tail_embeddings).view(batch_size, 1, self.embedding_dimensions)
             
@@ -729,7 +739,7 @@ class DistMult(BilinearDecoder):
         
         elif len(tail_embeddings.shape) == 3:
             assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
-                "When inferring tails, ..."
+                "When inferring tails, the tensors head_embeddings and edge_embeddings must have 2 dimensions."
             
             head_edge_embeddings = (head_embeddings * edge_embeddings).view(batch_size, 1, self.embedding_dimensions)
             
@@ -737,7 +747,7 @@ class DistMult(BilinearDecoder):
         
         elif len(edge_embeddings.shape) == 3:
             assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
-                "When inferring edges, ..."
+                "When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions."
 
             head_edge_embeddings = (head_embeddings.view(batch_size, 1, self.embedding_dimensions) * edge_embeddings)
             
@@ -760,10 +770,13 @@ class ComplEx(BilinearDecoder):
     ---------
     embedding_dimensions: int
         Dimensions of embeddings.
-    node_count: int
-        Number of nodes in the knowledge graph.
-    edge_count: int
-        Number of edges in the knowledge graph.
+
+    Arguments
+    ---------
+    embedding_dimensions: int
+        Dimensions of embeddings.
+    embedding_spaces: int
+        TODO.what_that_variable_is_or_does
         
     Attributes
     ----------
@@ -905,6 +918,8 @@ class ComplEx(BilinearDecoder):
             When inferring tails, the tensors head_embeddings and edge_embeddings must have 2 dimensions.
         AssertionError #3
             When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions.
+        ValueError
+            If none of the embeddings have a shape adapted to be inferred. Shapes must be of 3 for `head_embeddings`, `tail_embeddings` and `edge_embeddings`.
 
         Returns
         -------
@@ -925,7 +940,7 @@ class ComplEx(BilinearDecoder):
 
         if len(real_head_embeddings.shape) == 3:
             assert (len(real_tail_embeddings.shape) == 2) and (len(real_edge_embeddings.shape) == 2), \
-                "When inferring heads, ..."
+                "When inferring heads, the tensors tail_embeddings and edge_embeddings must have 2 dimensions."
             
             return (real_head_embeddings * 
                         (real_edge_embeddings * real_tail_embeddings 
@@ -939,7 +954,7 @@ class ComplEx(BilinearDecoder):
 
         elif len(real_tail_embeddings.shape) == 3:
             assert (len(real_head_embeddings.shape) == 2) and (len(real_edge_embeddings.shape) == 2), \
-                "When inferring tails, ..."
+                "When inferring tails, the tensors head_embeddings and edge_embeddings must have 2 dimensions."
             
             return ((real_head_embeddings * real_edge_embeddings
                         - imaginary_head_embeddings * imaginary_edge_embeddings
@@ -953,7 +968,7 @@ class ComplEx(BilinearDecoder):
 
         elif len(real_edge_embeddings.shape) == 3:
             assert (len(real_head_embeddings.shape) == 2) and (len(real_tail_embeddings.shape) == 2), \
-                "When inferring edges, ..."
+                "When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions."
             
             return ((real_head_embeddings * real_tail_embeddings
                         + imaginary_head_embeddings * imaginary_tail_embeddings

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -62,11 +62,11 @@ class ConvKB(ConvKBModel):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
 
         Returns

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -67,12 +67,12 @@ class ConvolutionalDecoder(Module):
             batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
                 The score of each triplet as a tensor.
         """
-        raise NotImplementedError("The score method must be implemented by the bilinear decoder.")
+        raise NotImplementedError("The score method must be implemented by the convolutional decoder.")
 
-    def normalize_parameters(self) -> Tuple[Tensor, Tensor] | None:
+    def normalize_parameters(self) -> Tuple[nn.ParameterList, nn.Embedding] | None:
         return None
 
-    def get_embeddings(self) -> Dict[str, Tensor] |None:
+    def get_embeddings(self) -> Dict[str, Tensor] | None:
         """Get the decoder-specific embeddings.
         
         If the decoder doesn't have dedicated embeddings, nothing is returned. In 
@@ -86,7 +86,7 @@ class ConvolutionalDecoder(Module):
         return None
 
     def inference_prepare_candidates(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-        pass
+        raise NotImplementedError("The inference_prepare_candidates method must be implemented by the convolutional decoder.")
 
     def inference_score(self, 
                         *,

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -15,9 +15,91 @@ import torch.nn as nn
 
 from torchkge.models import ConvKBModel
 
+class ConvolutionalDecoder(Module):
+    """Interface for convolutional decoders of KGATE.
+
+    This interface is largely inspired by TorchKGE's ConvKBModel, and exposes
+    the methods that all convolutional decoders must use to be compatible with KGATE.
+    The interface doesn't have an __init__ method as inheriting decoders are supposed
+    to take care of their initialization, and only requires one attribute to be set.
+
+    Furthermore, this interface doesn't implement anything but is a type helper.
+    """
+    
+    def score(self,
+        *,
+        head_embeddings: Tensor,
+        tail_embeddings: Tensor,
+        edge_embeddings: Tensor,
+        head_indices: Tensor,
+        tail_indices: Tensor,
+        edge_indices: Tensor
+        ) -> Tensor:
+        """Interface method for the decoder's score function.
+
+        Refer to the specific decoder for details on scoring function implementation.
+        While all arguments are given when called from the Architect class, most 
+        decoders only use some of them. 
+
+        Arguments
+        ---------
+        head_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+            The embeddings of the head entities for the current batch of length `batch_size`
+            (or the whole graph, if it fits in memory)
+        tail_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+            The embeddings of the tail entities for the current batch of length `batch_size` 
+            (or the whole graph, if it fits in memory)
+        edge_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+            The embeddings of the edges for the current batch of length `batch_size` 
+            (or the whole graph, if it fits in memory)
+        head_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+            The indices of the head entities for the current batch of length `batch_size` 
+            (or the whole graph, if it fits in memory)
+        tail_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+            The indices of the tail entities for the current batch of length `batch_size` 
+            (or the whole graph, if it fits in memory)
+        edge_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+            The indices of the edges for the current batch of length `batch_size` 
+            (or the whole graph, if it fits in memory)
+
+        Returns
+        -------
+            batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
+                The score of each triplet as a tensor.
+        """
+        raise NotImplementedError("The score method must be implemented by the bilinear decoder.")
+
+    def normalize_parameters(self) -> Tuple[Tensor, Tensor] | None:
+        return None
+
+    def get_embeddings(self) -> Dict[str, Tensor] |None:
+        """Get the decoder-specific embeddings.
+        
+        If the decoder doesn't have dedicated embeddings, nothing is returned. In 
+        this case, it is not necessary to implement this method from the interface.
+        
+        Returns
+        -------
+            embeddings: Dict[str, torch.Tensor] or None
+                Decoder-specific embeddings, or None.
+        """
+        return None
+
+    def inference_prepare_candidates(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        pass
+
+    def inference_score(self, 
+                        *,
+                        projected_heads: Tensor,
+                        projected_tails: Tensor,
+                        edges: Tensor
+                        ) -> Tensor:
+        """TODO docstring
+        """
+        raise NotImplementedError("Convolutional decoders must implement the inference_score function themselves.")
 
 
-class ConvKB(ConvKBModel):
+class ConvKB(ConvolutionalDecoder):
     """
     TODO.What_the_class_is_about_globally
 
@@ -47,16 +129,25 @@ class ConvKB(ConvKBModel):
                 node_count: int,
                 edge_count: int):
         
-        super().__init__(embedding_dimensions, filter_count, node_count, edge_count)
-        del self.ent_emb
-        del self.rel_emb
+        self.embedding_dimensions = embedding_dimensions
+        self.node_count = node_count
+        self.edge_cont = edge_count
+
+        self.convolution_layer = nn.Sequential(
+            nn.Conv1d(3, filter_count, 1, stride=1),
+            nn.ReLu()
+        )
+        self.output = nn.Sequential(
+            nn.Linear(self.embedding_dimensions * filter_count, 2),
+            nn.Softmax(dim=1)
+        )
 
         
     def score(self, *,
             head_embeddings: Tensor,
             tail_embeddings: Tensor,
             edge_embeddings: Tensor,
-            **_):
+            **_) -> Tensor:
         """
         TODO.What_the_function_does_about_globally
 
@@ -87,20 +178,8 @@ class ConvKB(ConvKBModel):
 
         concat = cat((head_score, edge_score, tail_score), dim=1)
 
-        return self.output(self.convlayer(concat).reshape(batch_size, -1))[:, 1]
-    
-    
-    def get_embeddings(self):
-        """
-        TODO.What_the_function_does_about_globally
-
-        Returns
-        -------
-        None
-        
-        """
-        return None
-    
+        convolution = self.convolution_layer(concat).reshape(batch_size, -1)
+        return self.output(convolution)[:, 1]    
     
     def inference_prepare_candidates(self, 
                                     head_indices: Tensor,
@@ -108,7 +187,7 @@ class ConvKB(ConvKBModel):
                                     edge_indices: Tensor, 
                                     node_embeddings: Tensor,
                                     edge_embeddings: nn.Embedding,
-                                    node_inference: bool = True):
+                                    node_inference: bool = True) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         TODO.What_the_class_is_about_globally
 
@@ -143,7 +222,7 @@ class ConvKB(ConvKBModel):
             Candidate embeddings for nodes or edges.
 
         """
-        batch_size = head_indices.shape[0]
+        batch_size = head_indices.size(0)
 
         # Get head, tail and edge embeddings
         head_embeddings = node_embeddings[head_indices]
@@ -158,6 +237,39 @@ class ConvKB(ConvKBModel):
             candidates = edge_embeddings.weight.data
         
         candidates = candidates.unsqueeze(0).expand(batch_size, -1, -1)
-        candidates = candidates.view(batch_size, -1, 1, self.emb_dim)
+        candidates = candidates.view(batch_size, -1, 1, self.embedding_dimensions)
 
         return head_embeddings, tail_embeddings, edge_embeddings_inference, candidates
+
+    def inference_score(self, *,
+                        head_embeddings: Tensor,
+                        tail_embeddings: Tensor,
+                        edge_embeddings: Tensor) -> Tensor:
+        batch_size = head_embeddings.size(0)
+
+        if len(head_embeddings.size()) == 4:
+            assert (len(tail_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 2), \
+                "When inferring heads..."
+            concatenation = cat((head_embeddings,
+                            edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
+                            tail_edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions)), dim = 2)
+
+        elif len(tail_embeddings.shape) == 4:
+            assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
+                "When inferring tails..."
+            concatenation = cat((head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
+                                edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
+                                tail_embeddings), dim=2)
+        
+        elif len(edge_embeddings.shape) == 4:
+            assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
+                "When inferring edges..."
+            concatenation = cat((head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.edge_count, 1, self.embedding_dimensions),
+                                edge_embeddings,
+                                tail_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.edge_count, 1, self.embedding_dimensions)), dim = 2)
+        
+        concatenation = concat.reshape(-1, 3, self.embedding_dimensions)
+
+        scores = self.output(self.convolution_layer(concatenation).reshape(concatenation.shape[0], -1))
+
+        return scores[:, :, 1]

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -43,9 +43,9 @@ class ConvolutionalDecoder(Module):
         """
         Interface method for the decoder's score function.
 
-        Refer to the specific decoder for details on scoring function implementation.
+        Refer to the specific decoder for details on this function's implementation.
         While all arguments are given when called from the Architect class, most 
-        decoders only use some of them. 
+        decoders only use some of them.
 
         Arguments
         ---------
@@ -61,6 +61,12 @@ class ConvolutionalDecoder(Module):
             The indices of the tail nodes for the current batch of length `batch_size`.
         edge_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the edges for the current batch of length `batch_size`.
+        
+        Raises
+        ------
+        NotImplementedError
+            The score method must be implemented by a convolutional decoder
+            inheriting from this interface.
 
         Returns
         -------
@@ -114,6 +120,8 @@ class ConvolutionalDecoder(Module):
     def get_embeddings(self) -> Dict[str, Tensor] | None:
         """
         Get the decoder-specific embeddings.
+
+        Refer to the specific decoder for details on this function's implementation.
         
         Returns
         -------
@@ -144,6 +152,10 @@ class ConvolutionalDecoder(Module):
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
         `inference_score_function` method.
+
+        Refer to the specific decoder for details on this function's implementation.
+        While all arguments are given when called from the Architect class, most 
+        decoders only use some of them.
         
         Arguments
         ---------
@@ -189,6 +201,10 @@ class ConvolutionalDecoder(Module):
                         ) -> Tensor:
         """
         TODO.what_that_function_does
+
+        Refer to the specific decoder for details on this function's implementation.
+        While all arguments are given when called from the Architect class, most 
+        decoders only use some of them.
         
         Arguments
         ---------

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -193,7 +193,7 @@ class ConvKB(ConvolutionalDecoder):
         Additional_info_from_the_dev_to_the_user
             
         """
-        batch_size = head_embeddings.size(0)
+        batch_size = head_embeddings.shape[0]
 
         head_score = head_embeddings.view(batch_size, 1, -1)
         tail_score = tail_embeddings.view(batch_size, 1, -1)
@@ -248,7 +248,7 @@ class ConvKB(ConvolutionalDecoder):
             Candidate embeddings for nodes or edges.
 
         """
-        batch_size = head_indices.size(0)
+        batch_size = head_indices.shape[0]
 
         # Get head, tail and edge embeddings
         head_embeddings = node_embeddings[head_indices]
@@ -277,10 +277,10 @@ class ConvKB(ConvolutionalDecoder):
         TODO.docstring
         
         """        
-        batch_size = head_embeddings.size(0)
+        batch_size = head_embeddings.shape[0]
 
-        if len(head_embeddings.size()) == 4:
-            assert (len(tail_embeddings.size()) == 2) and (len(edge_embeddings.size()) == 2), \
+        if len(head_embeddings.shape) == 4:
+            assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
                 "When inferring heads..."
             concatenation = cat((head_embeddings,
                             edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -333,10 +333,6 @@ class ConvKB(ConvolutionalDecoder):
         Link prediction evaluation helper function. Get node embeddings
         and edge embeddings. The output will be fed to the
         `inference_score_function` method.
-
-        References
-        ----------
-        TODO
         
         Arguments
         ---------

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -30,16 +30,15 @@ class ConvolutionalDecoder(Module):
     Furthermore, this interface doesn't implement anything but is a type helper.
     
     """
-    
-    def score(self,
-        *,
-        head_embeddings: Tensor,
-        tail_embeddings: Tensor,
-        edge_embeddings: Tensor,
-        head_indices: Tensor,
-        tail_indices: Tensor,
-        edge_indices: Tensor
-        ) -> Tensor:
+    def score(  self,
+                *,
+                head_embeddings: Tensor,
+                tail_embeddings: Tensor,
+                edge_embeddings: Tensor,
+                head_indices: Tensor,
+                tail_indices: Tensor,
+                edge_indices: Tensor
+                ) -> Tensor:
         """
         Interface method for the decoder's score function.
 
@@ -167,11 +166,11 @@ class ConvKB(ConvolutionalDecoder):
         )
 
         
-    def score(self, *,
-            head_embeddings: Tensor,
-            tail_embeddings: Tensor,
-            edge_embeddings: Tensor,
-            **_) -> Tensor:
+    def score(  self, *,
+                head_embeddings: Tensor,
+                tail_embeddings: Tensor,
+                edge_embeddings: Tensor,
+                **_) -> Tensor:
         """
         TODO.What_the_function_does_about_globally
 

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -233,7 +233,7 @@ class ConvKB(ConvolutionalDecoder):
             TODO.What_that_argument_is_or_does
         edge_embeddings: torch.nn.Embedding
             TODO.What_that_argument_is_or_does
-        node_inference: bool, default to True
+        node_inference: bool, optional, default to True
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -48,28 +48,28 @@ class ConvolutionalDecoder(Module):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        head_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the head entities for the current batch of length `batch_size`
             (or the whole graph, if it fits in memory)
-        tail_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        tail_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        edge_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        head_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        head_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the head entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        tail_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        tail_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        edge_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
 
         Returns
         -------
-            batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
+            batch_score: torch.Tensor, dtype: torch.float, shape: [batch_size]
                 The score of each triplet as a tensor.
         
         """

--- a/src/kgate/decoders/convolutional.py
+++ b/src/kgate/decoders/convolutional.py
@@ -423,25 +423,25 @@ class ConvKB(ConvolutionalDecoder):
 
         if len(head_embeddings.shape) == 4:
             assert (len(tail_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
-                "When inferring heads..."
+                "When inferring heads, the tensors tail_embeddings and edge_embeddings must have 2 dimensions."
             concatenation = cat((head_embeddings,
                             edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
                             tail_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions)), dim = 2)
 
         elif len(tail_embeddings.shape) == 4:
             assert (len(head_embeddings.shape) == 2) and (len(edge_embeddings.shape) == 2), \
-                "When inferring tails..."
+                "WWhen inferring tails, the tensors head_embeddings and edge_embeddings must have 2 dimensions."
             concatenation = cat((head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
                                 edge_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.node_count, 1, self.embedding_dimensions),
                                 tail_embeddings), dim=2)
         
         elif len(edge_embeddings.shape) == 4:
             assert (len(head_embeddings.shape) == 2) and (len(tail_embeddings.shape) == 2), \
-                "When inferring edges..."
+                "When inferring edges, the tensors head_embeddings and tail_embeddings must have 2 dimensions."
             concatenation = cat((head_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.edge_count, 1, self.embedding_dimensions),
                                 edge_embeddings,
                                 tail_embeddings.view(batch_size, 1, 1, self.embedding_dimensions).expand(batch_size, self.edge_count, 1, self.embedding_dimensions)), dim = 2)
-        
+        # TODO: is a ValueError else needed here?
         concatenation = concatenation.reshape(-1, 3, self.embedding_dimensions)
 
         convolution = self.convolution_layer(concatenation).reshape(concatenation.shape[0], -1)

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -1013,7 +1013,7 @@ class TransD(TranslationalDecoder):
         for i in tqdm(range(self.node_count), unit = "nodes", desc = "Projecting nodes"):
             edge_projection_vector = self.edge_projection_vector.weight.data
 
-            mask = tensor([i], device=edge_projection_vector.device).long()
+            mask = tensor([i], device = edge_projected_vectors.device).long()
 
             # TODO: find better name
             masked_node_embeddings = node_embeddings[mask]

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -133,23 +133,23 @@ class TranslationalDecoder(Module):
         TODO docstring
         
         """
-        batch_size = projected_heads.size(0)
+        batch_size = projected_heads.shape[0]
 
         # When the shape of the edges is (batch_size, embedding_dimensions)
-        if len(edges.size()) == 2:
-            if len(projected_tails.size()) == 3:
-                assert len(projected_heads.size()) == 2, "When inferring tails, the projected heads tensor should be of shape (batch_size, embedding_dimensions)"
+        if len(edges.shape) == 2:
+            if len(projected_tails.shape) == 3:
+                assert len(projected_heads.shape) == 2, "When inferring tails, the projected heads tensor should be of shape (batch_size, embedding_dimensions)"
 
                 translated_heads = (projected_heads + edges).view(batch_size, 1, edges.size(1))
                 return - self.dissimilarity(translated_heads, projected_tails)
             else:
-                assert (len(projected_heads.size()) == 3) and (len(projected_tails) == 2), "When inferring heads, the projected tails tensor should be of shape (batch_size, embedding_dimensions)"
+                assert (len(projected_heads.shape) == 3) and (len(projected_tails) == 2), "When inferring heads, the projected tails tensor should be of shape (batch_size, embedding_dimensions)"
 
                 edges_extended = edges.view(batch_size, 1, edges.size(1))
                 tails_extended = projected_tails.view(batch_size, 1, edges.size(1))
                 
                 return - self.dissimilarity(projected_heads + edges_extended, tails_extended)
-        elif len(edges.size()) == 3:
+        elif len(edges.shape) == 3:
             if hasattr(self, "evaluated_projections"):
                 projected_heads = projected_heads.view(batch_size, -1, edges.size(1))
                 projected_tails = projected_tails.view(batch_size, -1, edges.size(1))
@@ -909,7 +909,7 @@ class TransD(TranslationalDecoder):
     
     
     def project(self, nodes: Tensor, node_projection_vector: Tensor, edge_projection_vector: Tensor) -> Tensor:
-        batch_size = nodes.size(0)
+        batch_size = nodes.shape[0]
 
         scalar_product = (nodes * node_projection_vector).sum(dim = 1)
         projected_nodes = (edge_projection_vector * scalar_product.view(batch_size, 1))

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -14,19 +14,24 @@ from typing import Tuple, Dict, Literal
 
 from tqdm import tqdm
 
-from torch import nn, tensor, matmul, Module, Tensor, empty
+from torch import nn, tensor, matmul, Tensor, empty
 from torch.cuda import empty_cache
 from torch.nn.functional import normalize
-from torch.nn import ParameterList, Parameter
+from torch.nn import Module, Parameter, ParameterList
 
 from torchkge.models import TransEModel, TransHModel, TransRModel, TransDModel, TorusEModel
-from torchkge.utils.dissimilarities import l1_dissimilarity, l2_dissimilarity, \
-            l1_torus_dissimilarity, l2_torus_dissimilarity, el2_torus_dissimilarity
+from torchkge.utils.dissimilarities import  l1_dissimilarity, \
+                                            l2_dissimilarity, \
+                                            l1_torus_dissimilarity, \
+                                            l2_torus_dissimilarity, \
+                                            el2_torus_dissimilarity
 
 from ..utils import initialize_embedding
 
+
 class TranslationalDecoder(Module):
-    """Interface for translational decoders of KGATE.
+    """
+    Interface for translational decoders of KGATE.
 
     This interface is largely inspired by TorchKGE's TranslationModel, and exposes
     the methods that all translational decoders must use to be compatible with KGATE.

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -8,6 +8,7 @@ Modifications and additional functionalities added by Benjamin Loire <benjamin.l
 - 
 
 The modifications are licensed under the BSD license according to the source license.
+
 """
 
 from typing import Tuple, Dict, Literal
@@ -332,10 +333,6 @@ class TransE(TranslationalDecoder):
         """
         TODO.What_the_function_does_about_globally
 
-        References
-        ----------
-        TODO
-
         Arguments
         ---------
         head_embeddings: torch.Tensor, keyword-only
@@ -511,10 +508,6 @@ class TransH(TranslationalDecoder):
         """
         TODO.What_the_function_does_about_globally
 
-        References
-        ----------
-        TODO
-
         Arguments
         ---------
         head_embeddings: torch.Tensor, keyword-only
@@ -657,15 +650,15 @@ class TransH(TranslationalDecoder):
         link prediction makes the process faster by computing projections only
         once.
 
-        References
-        ----------
-        TODO
-
         Arguments
         ---------
         node_embeddings: torch.Tensor
             TODO.What_that_argument_is_or_does
-            
+        
+        Returns
+        -------
+        TODO
+
         """
         if self.evaluated_projections:
             return
@@ -747,10 +740,6 @@ class TransR(TranslationalDecoder):
                 **_) -> Tensor:
         """
         TODO.What_the_function_does_about_globally
-
-        References
-        ----------
-        TODO
 
         Arguments
         ---------
@@ -924,10 +913,6 @@ class TransR(TranslationalDecoder):
         link prediction makes the process faster by computing projections only
         once.
 
-        References
-        ----------
-        TODO
-
         Arguments
         ---------
         node_embeddings: torch.Tensor
@@ -1023,10 +1008,6 @@ class TransD(TranslationalDecoder):
                 **_) -> Tensor:
         """
         TODO.What_the_function_does_about_globally
-
-        References
-        ----------
-        TODO
 
         Arguments
         ---------
@@ -1214,10 +1195,6 @@ class TransD(TranslationalDecoder):
         link prediction makes the process faster by computing projections only
         once.
 
-        References
-        ----------
-        TODO
-
         Arguments
         ---------
         node_embeddings: torch.Tensor
@@ -1268,8 +1245,9 @@ class TorusE(TranslationalDecoder):
         Number of nodes in the knowledge graph.
     edge_count: int
         Number of edges in the knowledge graph.
-    dissimilarity_type: str
-        TODO.What_that_argument_is_or_does
+    dissimilarity_type: Literal["L1", "torus_L1", "torus_L2", "torus_eL2"]
+        The type of dissimilarity function that will be used,
+        either "L1", "torus_L1", "torus_L2" or "torus_eL2".
     
     Raises
     ------
@@ -1315,10 +1293,6 @@ class TorusE(TranslationalDecoder):
                 **_) -> Tensor:
         """
         TODO.What_the_function_does_about_globally
-
-        References
-        ----------
-        TODO
 
         Arguments
         ---------

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -64,28 +64,28 @@ class TranslationalDecoder(Module):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        head_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the head entities for the current batch of length `batch_size`
             (or the whole graph, if it fits in memory)
-        tail_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        tail_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_embeddings: torch.Tensor, dtype: torch.float, shape: (batch_size), keyword-only
+        edge_embeddings: torch.Tensor, dtype: torch.float, shape: [batch_size], keyword-only
             The embeddings of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        head_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        head_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the head entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        tail_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        tail_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the tail entities for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
-        edge_indices: torch.Tensor, dtype: torch.long, shape: (batch_size), keyword-only
+        edge_indices: torch.Tensor, dtype: torch.long, shape: [batch_size], keyword-only
             The indices of the edges for the current batch of length `batch_size` 
             (or the whole graph, if it fits in memory)
 
         Returns
         -------
-            batch_score: torch.Tensor, dtype: torch.float, shape: (batch_size)
+            batch_score: torch.Tensor, dtype: torch.float, shape: [batch_size]
                 The score of each triplet as a tensor.
         
         """

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -193,11 +193,11 @@ class TransE(TranslationalDecoder):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
 
         Returns
@@ -258,17 +258,17 @@ class TransE(TranslationalDecoder):
 
         Arguments
         ---------
-        head_indices : torch.Tensor
+        head_indices : torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices : torch.Tensor
+        tail_indices : torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices : torch.Tensor
+        edge_indices : torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference : bool, optional, default to True
+        node_inference : bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -346,13 +346,13 @@ class TransH(TranslationalDecoder):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the edges (from KG).
 
         Returns
@@ -435,17 +435,17 @@ class TransH(TranslationalDecoder):
 
         Arguments
         ---------
-        head_indices : torch.Tensor
+        head_indices : torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices : torch.Tensor
+        tail_indices : torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices : torch.Tensor
+        edge_indices : torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference : bool, optional, default to True
+        node_inference : bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -585,13 +585,13 @@ class TransR(TranslationalDecoder):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the edges (from KG).
 
         Returns
@@ -680,17 +680,17 @@ class TransR(TranslationalDecoder):
 
         Arguments
         ---------
-        head_indices : torch.Tensor
+        head_indices : torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices : torch.Tensor
+        tail_indices : torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices : torch.Tensor
+        edge_indices : torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference : bool, optional, default to True
+        node_inference : bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -835,17 +835,17 @@ class TransD(TranslationalDecoder):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
-        head_indices: torch.Tensor
+        head_indices: torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        tail_indices: torch.Tensor
+        tail_indices: torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
 
         Returns
@@ -941,17 +941,17 @@ class TransD(TranslationalDecoder):
 
         Arguments
         ---------
-        head_indices : torch.Tensor
+        head_indices : torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices : torch.Tensor
+        tail_indices : torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices : torch.Tensor
+        edge_indices : torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference : bool, optional, default to True
+        node_inference : bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns
@@ -1093,17 +1093,17 @@ class TorusE(TranslationalDecoder):
 
         Arguments
         ---------
-        head_embeddings: torch.Tensor
+        head_embeddings: torch.Tensor, keyword-only
             Embeddings of the head nodes in the knowledge graph.
-        tail_embeddings: torch.Tensor
+        tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
-        edge_embeddings: torch.Tensor
+        edge_embeddings: torch.Tensor, keyword-only
             The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
-        head_indices: torch.Tensor
+        head_indices: torch.Tensor, keyword-only
             Unused.
-        tail_indices: torch.Tensor
+        tail_indices: torch.Tensor, keyword-only
             Unused.
-        edge_indices: torch.Tensor
+        edge_indices: torch.Tensor, keyword-only
             Unused.
 
         Returns
@@ -1171,17 +1171,17 @@ class TorusE(TranslationalDecoder):
 
         Arguments
         ---------
-        head_indices : torch.Tensor
+        head_indices : torch.Tensor, keyword-only
             The indices of the head nodes (from KG).
-        tail_indices : torch.Tensor
+        tail_indices : torch.Tensor, keyword-only
             The indices of the tail nodes (from KG).
-        edge_indices : torch.Tensor
+        edge_indices : torch.Tensor, keyword-only
             The indices of the edges (from KG).
-        node_embeddings: torch.Tensor
+        node_embeddings: torch.Tensor, keyword-only
             TODO.What_that_argument_is_or_does
-        edge_embeddings: torch.nn.Embedding
+        edge_embeddings: torch.nn.Embedding, keyword-only
             TODO.What_that_argument_is_or_does
-        node_inference : bool, optional, default to True
+        node_inference : bool, optional, default to True, keyword-only
             If True, prepare candidate nodes; otherwise, prepare candidate edges.
 
         Returns

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -89,10 +89,10 @@ class TranslationalDecoder(Module):
         """
         raise NotImplementedError("The score method must be implemented by the translational decoder.")
 
-    def normalize_parameters(self):
-        pass
+    def normalize_parameters(self) -> Tuple[nn.ParameterList, nn.Embedding] | None:
+        return None
 
-    def get_embeddings(self) -> Dict[str, Tensor] |None:
+    def get_embeddings(self) -> Dict[str, Tensor] | None:
         """Get the decoder-specific embeddings.
         
         If the decoder doesn't have dedicated embeddings, nothing is returned. In 
@@ -105,15 +105,15 @@ class TranslationalDecoder(Module):
         """
         return None
 
-    def inference_prepare_candidates(self):
-        pass
+    def inference_prepare_candidates(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        raise NotImplementedError("The inference_prepare_candidates method must be implemented by the translational decoder.")
 
     def inference_score(self, 
                         *,
                         projected_heads: Tensor,
                         projected_tails: Tensor,
                         edges: Tensor
-                        ):
+                        ) -> Tensor:
         """TODO docstring
         """
         batch_size = projected_heads.size(0)

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -278,6 +278,7 @@ class TranslationalDecoder(Module):
                 tail_embeddings = tail_embeddings.view(batch_size, -1, tail_embeddings.size(1))
 
             return - self.dissimilarity(head_embeddings + edge_embeddings, tail_embeddings)
+        # TODO: would a ValueError else be needed?
 
 
 
@@ -340,7 +341,7 @@ class TransE(TranslationalDecoder):
         tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
         edge_embeddings: torch.Tensor, keyword-only
-            The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
+            The edge embeddings, of size (edge_count, edge_embedding_dimensions)
 
         Returns
         -------
@@ -456,9 +457,15 @@ class TransH(TranslationalDecoder):
 
     Attributes
     ----------
+    normal_vector: TODO.type
+        TODO.what_that_variable_is_or_does
     dissimilarity: function described in `torchkge.utils.dissimilarities`
         The dissimilarity function used to compare translated head embeddings 
         to tail embeddings.
+    evaluated_projections: bool
+        TODO.what_that_variable_is_or_does
+    projected_nodes: TODO.type
+        TODO.what_that_variable_is_or_does
     
     """
     def __init__(self,
@@ -515,7 +522,7 @@ class TransH(TranslationalDecoder):
         tail_embeddings: torch.Tensor, keyword-only
             Embeddings of the tail nodes in the knowledge graph.
         edge_embeddings: torch.Tensor, keyword-only
-            The edge embeddings, of size (n_rel, rel_emb_dim) corresponding to (edge_count, edge_embedding_dimensions)
+            The edge embeddings, of size (edge_count, edge_embedding_dimensions)
         edge_indices: torch.Tensor, keyword-only
             The indices of the edges (from KG).
 
@@ -575,7 +582,7 @@ class TransH(TranslationalDecoder):
 
         Returns
         -------
-        result_1: Dict[str, Tensor]
+        normal_vector: Dict[str, Tensor]
             TODO.What_that_variable_is_or_does
             
         """
@@ -631,13 +638,13 @@ class TransH(TranslationalDecoder):
         edge_embeddings_inference = edge_embeddings(edge_indices)
 
         if node_inference:
-            head_embeddings = self.projected_nodes[edge_indices, head_indices]  # shape: (batch_size, self.emb_dim)
-            tail_embeddings = self.projected_nodes[edge_indices, tail_indices]  # shape: (batch_size, self.emb_dim)
-            candidates = self.projected_nodes[edge_indices]  # shape: (batch_size, self.n_rel, self.emb_dim)
+            head_embeddings = self.projected_nodes[edge_indices, head_indices]  # shape: (batch_size, self.node_embedding_dimensions)
+            tail_embeddings = self.projected_nodes[edge_indices, tail_indices]  # shape: (batch_size, self.node_embedding_dimensions)
+            candidates = self.projected_nodes[edge_indices]  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
         else:
-            head_embeddings = self.projected_nodes[:, head_indices].transpose(0, 1)  # shape: (batch_size, self.n_rel, self.emb_dim)
-            tail_embeddings = self.projected_nodes[:, tail_indices].transpose(0, 1)  # shape: (batch_size, self.n_rel, self.emb_dim)
-            candidates = edge_embeddings.weight.data.unsqueeze(0).expand(batch_size, self.n_rel, self.emb_dim)  # shape: (batch_size, self.n_rel, self.emb_dim)
+            head_embeddings = self.projected_nodes[:, head_indices].transpose(0, 1)  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
+            tail_embeddings = self.projected_nodes[:, tail_indices].transpose(0, 1)  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
+            candidates = edge_embeddings.weight.data.unsqueeze(0).expand(batch_size, self.n_rel, self.emb_dim)  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
 
         return head_embeddings, tail_embeddings, edge_embeddings_inference, candidates
 
@@ -704,9 +711,23 @@ class TransR(TranslationalDecoder):
 
     Attributes
     ----------
+    node_count: int
+        Number of nodes in the knowledge graph.
+    edge_count: int
+        Number of edges in the knowledge graph.
+    node_embedding_dimensions: int
+        Dimensions of node embeddings.
+    edge_embedding_dimensions: int
+        Dimensions of edge embeddings.
+    projection_matrix: TODO.type
+        TODO.what_that_variable_is_or_does
     dissimilarity: function described in `torchkge.utils.dissimilarities`
         The dissimilarity function used to compare translated head embeddings 
         to tail embeddings.
+    evaluated_projections: bool
+        TODO.what_that_variable_is_or_does
+    projected_nodes: TODO.type
+        TODO.what_that_variable_is_or_does
     
     """
     def __init__(self,
@@ -837,7 +858,7 @@ class TransR(TranslationalDecoder):
 
         Returns
         -------
-        result_1: Dict[str, Tensor]
+        projection_matrix: Dict[str, Tensor]
             TODO.What_that_variable_is_or_does
             
         """
@@ -970,9 +991,25 @@ class TransD(TranslationalDecoder):
 
     Attributes
     ----------
+    node_count: int
+        Number of nodes in the knowledge graph.
+    edge_count: int
+        Number of edges in the knowledge graph.
+    node_embedding_dimensions: int
+        Dimensions of node embeddings.
+    edge_embedding_dimensions: int
+        Dimensions of edge embeddings.
+    node_projection_vector: TODO.type
+        TODO.what_that_variable_is_or_does
+    edge_projection_vector: TODO.type
+        TODO.what_that_variable_is_or_does
     dissimilarity: function described in `torchkge.utils.dissimilarities`
         The dissimilarity function used to compare translated head embeddings 
         to tail embeddings.
+    evaluated_projections: bool
+        TODO.what_that_variable_is_or_does
+    projected_nodes: TODO.type
+        TODO.what_that_variable_is_or_does
     
     """
     def __init__(self,
@@ -980,12 +1017,13 @@ class TransD(TranslationalDecoder):
                 edge_embedding_dimensions: int,
                 node_count: int,
                 edge_count: int):
+        
         self.node_count = node_count
         self.edge_count = edge_count
         self.node_embedding_dimensions = node_embedding_dimensions
         self.edge_embedding_dimensions = edge_embedding_dimensions
 
-        # Might be changed to have 2 embedding spaces instead (meaning it will be encoded by a GNN if present)
+        # TODO: Might be changed to have 2 embedding spaces instead (meaning it will be encoded by a GNN if present)
         self.node_projection_vector = initialize_embedding(self.node_count, self.node_embedding_dimensions)
         self.edge_projection_vector = initialize_embedding(self.edge_count, self.edge_embedding_dimensions)
 
@@ -1026,7 +1064,7 @@ class TransD(TranslationalDecoder):
 
         Returns
         -------
-        result_1: torch.Tensor
+        dissimilarity: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -1176,13 +1214,13 @@ class TransD(TranslationalDecoder):
         edge_embeddings_inference = edge_embeddings(edge_indices)
 
         if node_inference:
-            head_embeddings = self.projected_nodes[edge_indices, head_indices]  # shape: (batch_size, self.emb_dim)
-            tail_embeddings = self.projected_nodes[edge_indices, tail_indices]  # shape: (batch_size, self.emb_dim)
-            candidates = self.projected_nodes[edge_indices]  # shape: (batch_size, self.n_rel, self.emb_dim)
+            head_embeddings = self.projected_nodes[edge_indices, head_indices]  # shape: (batch_size, self.node_embedding_dimensions)
+            tail_embeddings = self.projected_nodes[edge_indices, tail_indices]  # shape: (batch_size, self.node_embedding_dimensions)
+            candidates = self.projected_nodes[edge_indices]  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
         else:
-            head_embeddings = self.projected_nodes[:, head_indices].transpose(0, 1)  # shape: (batch_size, self.n_rel, self.rel_emb_dim)
-            tail_embeddings = self.projected_nodes[:, tail_indices].transpose(0, 1)  # shape: (batch_size, self.n_rel, self.rel_emb_dim)
-            candidates = self.rel_emb.weight.data.unsqueeze(0).expand(batch_size, self.n_rel, self.rel_emb_dim)  # shape: (batch_size, self.n_rel, self.emb_dim)
+            head_embeddings = self.projected_nodes[:, head_indices].transpose(0, 1)  # shape: (batch_size, self.edge_count, self.edge_embedding_dimensions)
+            tail_embeddings = self.projected_nodes[:, tail_indices].transpose(0, 1)  # shape: (batch_size, self.edge_count, self.edge_embedding_dimensions)
+            candidates = self.rel_emb.weight.data.unsqueeze(0).expand(batch_size, self.edge_count, self.edge_embedding_dimensions)  # shape: (batch_size, self.edge_count, self.node_embedding_dimensions)
 
         return head_embeddings, tail_embeddings, edge_embeddings_inference, candidates
 
@@ -1219,7 +1257,7 @@ class TransD(TranslationalDecoder):
             node_projection_vector = self.node_projection_vector.weight[i]
 
             scalar_product = (node_projection_vector * masked_node_embeddings).sum(dim = 0)
-            projected_nodes = scalar_product * edge_projection_vector + masked_node_embeddings[:self.rel_emb_dim].view(1, -1)
+            projected_nodes = scalar_product * edge_projection_vector + masked_node_embeddings[:self.edge_embedding_dimensions].view(1, -1)
 
             self.projected_nodes[:, i, :] = projected_nodes
 
@@ -1259,6 +1297,8 @@ class TorusE(TranslationalDecoder):
     dissimilarity: function described in `torchkge.utils.dissimilarities`
         The dissimilarity function used to compare translated head embeddings 
         to tail embeddings.
+    normalized: bool
+        TODO.what_that_variable_is_or_does
     
     """
     def __init__(self,

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -1,4 +1,7 @@
-"""Collections of encoder classes to embed the graph structure into a latent space."""
+"""
+Collections of encoder classes to embed the graph structure into a latent space.
+
+"""
 
 import sys
 import logging
@@ -24,6 +27,8 @@ logging.basicConfig(
 
 class DefaultEncoder(nn.Module):
     """
+    Interface for encoders of KGATE.
+
     TODO.What_the_class_is_about_globally
 
     References
@@ -32,7 +37,7 @@ class DefaultEncoder(nn.Module):
 
     Attributes
     ----------
-    deep: bool, defaul to False
+    deep: bool, default to False
         TODO.What_that_variable_is_or_does
     TODO.inherited_attributes
     

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -96,7 +96,8 @@ class GNN(nn.Module):
 
     def forward(self,
                 x_dict: Dict[str, Tensor],
-                edge_index_dict: Dict[Tuple[str, str, str,], Tensor]):
+                edge_index_dict: Dict[Tuple[str, str, str,], Tensor]
+                ) -> Dict[str, Tensor]:
         """
         TODO.What_the_function_does_about_globally
 
@@ -113,7 +114,7 @@ class GNN(nn.Module):
 
         Returns
         -------
-        x_dict: TODO.type
+        x_dict: Dict[str, Tensor]
             TODO.What_that_variable_is_or_does
             
         """

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -7,25 +7,72 @@ from typing import List, Dict, Tuple
 
 from tqdm import tqdm
 
-import torch.nn as nn
 import torch
-import torch.nn.functional as F
 from torch import Tensor
+import torch.nn as nn
+import torch.nn.functional as F
 
-from torch_geometric.nn import HeteroConv, GATv2Conv, SAGEConv, Node2Vec
+from torch_geometric.nn import GATv2Conv, HeteroConv, Node2Vec, SAGEConv
+
 
 logging_level = logging.INFO
 logging.basicConfig(
-    level=logging_level,  
-    format="%(asctime)s - %(levelname)s - %(message)s" 
+    level = logging_level,  
+    format = "%(asctime)s - %(levelname)s - %(message)s" 
 )
 
+
 class DefaultEncoder(nn.Module):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Attributes
+    ----------
+    deep: bool, defaul to False
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
+    
+    """
     def __init__(self):
         super().__init__()
         self.deep = False
 
+
+
 class GNN(nn.Module):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    edge_types: List[Tuple[str, str, str]]
+        TODO.What_that_argument_is_or_does
+    aggregation: str, default to "sum"
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    deep: bool, default to True
+        TODO.What_that_variable_is_or_does
+    device: str, default to "cuda"
+        TODO.What_that_variable_is_or_does
+    aggregation: str, default to "sum"
+        TODO.What_that_variable_is_or_does
+    convolutions: nn.ModuleList()
+        TODO.What_that_variable_is_or_does
+    edge_types: List[Tuple[str, str, str]]
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
+    
+    """
     def __init__(self,
                 edge_types: List[Tuple[str, str, str]],
                 aggregation: str = "sum"):
@@ -48,7 +95,26 @@ class GNN(nn.Module):
     def forward(self,
                 x_dict: Dict[str, Tensor],
                 edge_index_dict: Dict[Tuple[str, str, str,], Tensor]):
+        """
+        TODO.What_the_function_does_about_globally
 
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        x_dict: Dict[str, Tensor]
+            TODO.What_that_argument_is_or_does
+        edge_index_dict: Dict[Tuple[str, str, str,], Tensor]
+            TODO.What_that_argument_is_or_does
+
+        Returns
+        -------
+        x_dict: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         for _, conv in enumerate(self.convolutions):
             x_dict = conv(x_dict = x_dict, edge_index_dict = edge_index_dict)
             x_dict = {key: F.leaky_relu(x) for key, x in x_dict.items()}
@@ -56,7 +122,43 @@ class GNN(nn.Module):
         return x_dict
     
 
+
 class GATEncoder(GNN):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    edge_types: List[Tuple[str, str, str]]
+        TODO.What_that_argument_is_or_does
+    embedding_dimensions: int
+        TODO.What_that_argument_is_or_does
+    gat_layer_count: int, default to 2
+        TODO.What_that_argument_is_or_does
+    aggregation: str, default to "sum"
+        TODO.What_that_argument_is_or_does
+    device: str, default to "cuda"
+        TODO.What_that_argument_is_or_does
+    add_self_loops: bool, default to True
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    layer_count: TODO.type
+        TODO.What_that_variable_is_or_does
+    edge_types: TODO.type
+        TODO.What_that_variable_is_or_does
+    aggregation: TODO.type
+        TODO.What_that_variable_is_or_does
+    convolutions: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
+    
+    """
     def __init__(self,
                 edge_types: List[Tuple[str, str, str]],
                 embedding_dimensions: int,
@@ -64,21 +166,59 @@ class GATEncoder(GNN):
                 aggregation: str = "sum",
                 device: str = "cuda",
                 add_self_loops: bool = True):
+        
         super().__init__(edge_types, add_self_loops, aggregation)
         self.layer_count = gat_layer_count
 
         for _ in range(gat_layer_count):
-            # Add_self_loops doesn"t work on heterogeneous graphs as per https://github.com/pyg-team/pytorch_geometric/issues/8121#issuecomment-1751129825  
+            # Add_self_loops doesn't work on heterogeneous graphs as per https://github.com/pyg-team/pytorch_geometric/issues/8121#issuecomment-1751129825  
             convolution = HeteroConv(
-            {edge_type: GATv2Conv(  in_channels = -1,
-                                    out_channels = embedding_dimensions,
-                                    add_self_loops = False)
-                for edge_type in self.edge_types},
-            aggr=self.aggregation
-            ).to(device)
+                {edge_type: GATv2Conv(  in_channels = -1,
+                                        out_channels = embedding_dimensions,
+                                        add_self_loops = False)
+                    for edge_type in self.edge_types},
+                aggr = self.aggregation
+                ).to(device)
             self.convolutions.append(convolution)
-        
+
+
+
 class GCNEncoder(GNN):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    edge_types: List[Tuple[str, str, str]]
+        TODO.What_that_argument_is_or_does
+    embedding_dimensions: int
+        TODO.What_that_argument_is_or_does
+    gcn_layer_count: int, default to 2
+        TODO.What_that_argument_is_or_does
+    aggregation: str, default to "sum"
+        TODO.What_that_argument_is_or_does
+    device: str, default to "cuda"
+        TODO.What_that_argument_is_or_does
+    add_self_loops: bool, default to True
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    layer_count: TODO.type
+        TODO.What_that_variable_is_or_does
+    edge_types: TODO.type
+        TODO.What_that_variable_is_or_does
+    aggregation: TODO.type
+        TODO.What_that_variable_is_or_does
+    convolutions: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
+    
+    """
     def __init__(self,
                 edge_types: List[Tuple[str, str, str]],
                 embedding_dimensions: int,
@@ -86,27 +226,67 @@ class GCNEncoder(GNN):
                 aggregation: str = "sum",
                 device: str = "cuda",
                 add_self_loops: bool = True):
+        
         super().__init__(edge_types, add_self_loops, aggregation)
         self.layer_count = gcn_layer_count
         
         for _ in range(gcn_layer_count):
             convolution = HeteroConv(
-            {edge_type: SAGEConv(   in_channels = -1,
-                                    out_channels = embedding_dimensions,
-                                    aggregation = "mean")
-                for edge_type in self.edge_types},
-            aggr=self.aggregation
-            ).to(device)
+                {edge_type: SAGEConv(   in_channels = -1,
+                                        out_channels = embedding_dimensions,
+                                        aggregation = "mean")
+                    for edge_type in self.edge_types},
+                aggr = self.aggregation
+                ).to(device)
             self.convolutions.append(convolution)
 
+
+
 class Node2VecEncoder:
-    def __init__(self, 
-                edge_index: Tensor, 
-                embedding_dimensions: int, 
-                walk_length: int, 
-                context_size: int, 
-                device: torch.device, 
-                output_directory: Path, 
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    edge_index: torch.Tensor
+        TODO.What_that_argument_is_or_does
+    embedding_dimensions: int
+        TODO.What_that_argument_is_or_does
+    walk_length: int
+        TODO.What_that_argument_is_or_does
+    context_size: int
+        TODO.What_that_argument_is_or_does
+    device: torch.device
+        TODO.What_that_argument_is_or_does
+    output_directory: Path
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    device: torch.device
+        TODO.What_that_variable_is_or_does
+    output_directory: Path
+        TODO.What_that_variable_is_or_does
+    model: TODO.type
+        TODO.What_that_variable_is_or_does
+    loader: TODO.type
+        TODO.What_that_variable_is_or_does
+    optimizer: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
+    
+    """
+    def __init__(self,
+                edge_index: Tensor,
+                embedding_dimensions: int,
+                walk_length: int,
+                context_size: int,
+                device: torch.device,
+                output_directory: Path,
                 **node2vec_kwargs):
         self.device = device
         self.output_directory = output_directory
@@ -116,13 +296,22 @@ class Node2VecEncoder:
             walk_length = walk_length,
             context_size = context_size,
             **node2vec_kwargs
-        ).to(device)
+            ).to(device)
 
         workers_count = 4 if sys.platform == 'linux' else 0
         self.loader = self.model.loader(batch_size = 128, shuffle = True, num_workers = workers_count)
         self.optimizer = torch.optim.SparseAdam(list(self.model.parameters()), lr = 0.01)
     
+    
     def generate_embeddings(self):
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+        
+        """
         for epoch in range(1,101):
             epoch_loss = 0
             for positive_random_walk, negative_random_walk in tqdm(self.loader):

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -108,14 +108,20 @@ class GNN(nn.Module):
         Arguments
         ---------
         x_dict: Dict[str, Tensor]
-            TODO.What_that_argument_is_or_does
+            Key (str): node type
+            Value (Tensor): [node_count for the node_type, embedding_dimension]
+            PyTorch Geometric equivalent to node_embeddings.
         edge_index_dict: Dict[Tuple[str, str, str,], Tensor]
-            TODO.What_that_argument_is_or_does
+            Key (Tuple[str, str, str,]): Tuple[head_type, edge_type, tail_type]
+            Value (Tensor): [head_index, tail_index] for the corresponding head_type and tail_type
+            PyTorch Geometric equivalent to triplet_type.
 
         Returns
         -------
         x_dict: Dict[str, Tensor]
-            TODO.What_that_variable_is_or_does
+            Key (str): node type
+            Value (Tensor): [node_count for the node_type, embedding_dimension]
+            PyTorch Geometric equivalent to node_embeddings.
             
         """
         for _, conv in enumerate(self.convolutions):

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -38,6 +38,7 @@ class DefaultEncoder(nn.Module):
     
     """
     def __init__(self):
+        
         super().__init__()
         self.deep = False
 
@@ -76,6 +77,7 @@ class GNN(nn.Module):
     def __init__(self,
                 edge_types: List[Tuple[str, str, str]],
                 aggregation: str = "sum"):
+        
         super().__init__()
         self.deep = True
         self.device = "cuda"
@@ -277,7 +279,6 @@ class Node2VecEncoder:
         TODO.What_that_variable_is_or_does
     optimizer: TODO.type
         TODO.What_that_variable_is_or_does
-    TODO.inherited_attributes
     
     """
     def __init__(self,

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -101,10 +101,12 @@ class LinkPredictionEvaluator(eval.LinkPredictionEvaluator):
             Decoder model to evaluate.
         kg: KnowledgeGraph
             Knowledge graph on which the evaluation will be done.
-        node_embeddings: nn.ParameterList
-            A list containing all embeddings (values) for each node type (indices).
-        edge_embeddings: nn.Embedding
-            A tensor containing one embedding by edge type.
+        node_embeddings: nn.ParameterList, keyword-only
+            A list containing all embeddings for each node type.
+            keys: node type index
+            values: tensors of shape (node_count, embedding_dimensions)
+        edge_embeddings: nn.Embedding, keyword-only
+            A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
         verbose: bool
             Indicate whether a progress bar should be displayed during
             evaluation.

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -59,18 +59,18 @@ class LinkPredictionEvaluator(eval.LinkPredictionEvaluator):
         been called.
     kg: KnowledgeGraph
         Knowledge graph on which the evaluation will be done.
-    rank_true_heads: torch.Tensor, shape: (triplet_count), dtype: `torch.int`
+    rank_true_heads: torch.Tensor, shape: [triplet_count], dtype: `torch.int`
         For each fact, this is the rank of the true head when all nodes
         are ranked as possible replacement of the head node. They are
         ranked in decreasing order of scoring function :math:`f_r(h,t)`.
-    rank_true_tails: torch.Tensor, shape: (triplet_count), dtype: `torch.int`
+    rank_true_tails: torch.Tensor, shape: [triplet_count], dtype: `torch.int`
         For each fact, this is the rank of the true tail when all nodes
         are ranked as possible replacement of the tail node. They are
         ranked in decreasing order of scoring function :math:`f_r(h,t)`.
-    filtered_rank_true_heads: torch.Tensor, shape: (triplet_count), dtype: `torch.int`
+    filtered_rank_true_heads: torch.Tensor, shape: [triplet_count], dtype: `torch.int`
         This is the same as the `rank_of_true_heads` when in the filtered
         case. See referenced paper by Bordes et al. for more information.
-    filtered_rank_true_tails: torch.Tensor, shape: (triplet_count), dtype: `torch.int`
+    filtered_rank_true_tails: torch.Tensor, shape: [triplet_count], dtype: `torch.int`
         This is the same as the `rank_of_true_tails` when in the filtered
         case. See referenced paper by Bordes et al. for more information.
 

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -306,7 +306,6 @@ class TripletClassificationEvaluator(eval.TripletClassificationEvaluator):
                 batch_size: int,
                 kg: KnowledgeGraph):
         """
-        TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO TODO
         Find edge thresholds using the validation set. As described in
         the paper by Socher et al., for an edge, the threshold is a value t
         such that if the score of a triplet is larger than t, the triplet is correct.

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -10,7 +10,7 @@ Modifications and additional functionalities added by Benjamin Loire <benjamin.l
 The modifications are licensed under the BSD license according to the source license.
 """
 
-from typing import Dict
+from typing import Dict, Tuple
 
 from tqdm import tqdm
 
@@ -31,47 +31,121 @@ from .knowledgegraph import KnowledgeGraph
 from .samplers import PositionalNegativeSampler
 from .utils import filter_scores
 
+
+
 class Predictions:
-    """Object holding the predictions output of an Evaluator.
+    """
+    Object holding the predictions output of an Evaluator.
     
     Predictions are available as a dataframe, but can also be accessed through
-    builtin methods to get specific metrics."""
+    builtin methods to get specific metrics.
+
+    Arguments
+    ---------
+    true_predictions_rank: torch.Tensor
+        TODO.What_that_argument_is_or_does
+    filtered_true_predictions_rank: torch.Tensor
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    true_predictions_rank: torch.Tensor
+        TODO.What_that_argument_is_or_does
+    filtered_true_predictions_rank: torch.Tensor
+        TODO.What_that_argument_is_or_does
+    
+    
+    """
     def __init__(self,
-                 true_predictions_rank: Tensor,
-                 filtered_true_predictions_rank: Tensor):
-                 
+                true_predictions_rank: Tensor,
+                filtered_true_predictions_rank: Tensor):
+
         self.true_predictions_rank = true_predictions_rank
         self.filtered_true_predictions_rank = filtered_true_predictions_rank
     
+    
     def __str__(self):
         k = 10
-        return f"""Hit@{k}: {round(self.hit_at_k(k)[0],3)} \t Filtered Hit@{k}: {round(self.hit_at_k(k)[1],3)} 
+        message = f"""
+        Hit@{k}: {round(self.hit_at_k(k)[0],3)} \t Filtered Hit@{k}: {round(self.hit_at_k(k)[1],3)} 
 
         MRR: {round(self.mrr()[0],3)} \t Filtered MRR: {round(self.mrr()[1],3)}
 
         Mean Rank: {int(self.mean_rank()[0])} \t Filtered Mean Rank: {int(self.mean_rank()[1])}
         """
+        
+        return message
 
-    def mean_rank(self):
-        """Mean rank metric"""
+
+    def mean_rank(self) -> Tuple[float, float]:
+        """
+        Mean rank metric
+        
+        TODO.What_the_function_does_about_globally
+
+        Returns
+        -------
+        mean_rank_score: float
+            TODO.What_that_variable_is_or_does
+        filtered_mean_rank_score: float
+            TODO.What_that_variable_is_or_does
+        
+        """
         mean_rank_score = self.true_predictions_rank.float().mean().item()
 
         filtered_mean_rank_score = self.filtered_true_predictions_rank.float().mean().item()
 
         return mean_rank_score, filtered_mean_rank_score
     
-    def hit_at_k(self, k: int=10):
+    
+    def hit_at_k(self,
+                k: int = 10
+                ) -> Tuple[float, float]:
+        """
+        Return the frequence at which the true triplet is within the k first predictions.
+        
+        Arguments
+        ---------
+        k: int, default to 10
+            The true triplet must be within the k first predictions.
+        
+        Returns
+        -------
+        true_prediction_hit: float
+            TODO.What_that_variable_is_or_does
+        filtered_true_prediction_hit: float
+            TODO.What_that_variable_is_or_does
+        
+        """
         true_prediction_hit = (self.true_predictions_rank <= k).float().mean().item()
         filtered_true_prediction_hit = (self.filtered_true_predictions_rank <= k).float().mean().item()
         
         return true_prediction_hit, filtered_true_prediction_hit
     
-    def mrr(self):
-        mrr = self.true_predictions_rank.float()**(-1).mean()
-        filtered_mrr = self.filtered_true_predictions_rank.float()**(-1).mean()
+    
+    def mrr(self) -> Tuple[float, float]:
+        """
+        Mean reciprocal rank
+        
+        TODO.What_the_function_does_about_globally
+
+        Returns
+        -------
+        mrr: float
+            TODO.What_that_variable_is_or_does
+            Inverse of the position of the true triplet prediction.
+            If the true triplet is predicted in 100th position, then mrr = 0.01
+        filtered_mrr: float
+            TODO.What_that_variable_is_or_does
+        
+        """
+        mrr = self.true_predictions_rank.float()**(-1).mean().item()
+        filtered_mrr = self.filtered_true_predictions_rank.float()**(-1).mean().item()
 
         return mrr, filtered_mrr
-    
+
+
+
 class LinkPredictionEvaluator:
     """
     Evaluate performance of given embedding using link prediction method.

--- a/src/kgate/grid_search.py
+++ b/src/kgate/grid_search.py
@@ -80,23 +80,23 @@ def suggest_value(  trial: optuna.trial.Trial,
                     value: int | float | list, # TODO check if the types are correct
                     ) -> int | float | list: # TODO check if the types are correct
     """
-        TODO.What_the_function_does_about_globally
-
-        Arguments
-        ---------
-        trial: optuna.trial.Trial
-            TODO.What_that_argument_is_or_does
-        value_name: str
-            TODO.What_that_argument_is_or_does
-        value: int or float or list
-            TODO.What_that_argument_is_or_does
-
-        Returns
-        -------
-        suggested_value: int or float or list
-            The value suggested.
-            
-        """
+    TODO.What_the_function_does_about_globally
+    
+    Arguments
+    ---------
+    trial: optuna.trial.Trial
+        TODO.What_that_argument_is_or_does
+    value_name: str
+        TODO.What_that_argument_is_or_does
+    value: int or float or list
+        TODO.What_that_argument_is_or_does
+    
+    Returns
+    -------
+    suggested_value: int or float or list
+        The value suggested.
+    
+    """
     logging.info(value_name)
     logging.info(value)
     

--- a/src/kgate/grid_search.py
+++ b/src/kgate/grid_search.py
@@ -4,8 +4,6 @@ from typing import Tuple, Any
 import optuna
 import pandas as pd
 
-from torchkge import KnowledgeGraph
-
 from .architect import Architect
 from .knowledgegraph import KnowledgeGraph
 from .utils import parse_config
@@ -17,6 +15,7 @@ logging.basicConfig(
     level = logging_level,  
     format = "%(asctime)s - %(levelname)s - %(message)s" 
 )
+
 
 def run_grid_search(config_path: str,
                     number_of_trials: int = 10,
@@ -37,9 +36,9 @@ def run_grid_search(config_path: str,
     ---------
     number_of_trials: int, default to 10
         TODO.What_that_argument_is_or_does
-    kg: Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph] or KnowledgeGraph, optional, default to None
-        Knowledge graph.
-    dataframe: pd.DataFrame, optional, default to None
+    kg: Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph] or KnowledgeGraph, optional
+        Knowledge graph on which a grid search hyperparameter optimization will be done.
+    dataframe: pd.DataFrame, optional
         TODO.What_that_argument_is_or_does
     
     Notes
@@ -78,7 +77,8 @@ def run_grid_search(config_path: str,
 
 def suggest_value(  trial: optuna.trial.Trial,
                     value_name: str,
-                    value: Any):
+                    value: int | float | list, # TODO check if the types are correct
+                    ) -> int | float | list: # TODO check if the types are correct
     """
         TODO.What_the_function_does_about_globally
 
@@ -88,13 +88,13 @@ def suggest_value(  trial: optuna.trial.Trial,
             TODO.What_that_argument_is_or_does
         value_name: str
             TODO.What_that_argument_is_or_does
-        value: Any
+        value: int or float or list
             TODO.What_that_argument_is_or_does
 
         Returns
         -------
-        suggested_value: TODO.type
-            TODO.What_that_variable_is_or_does
+        suggested_value: int or float or list
+            The value suggested.
             
         """
     logging.info(value_name)
@@ -111,7 +111,6 @@ def suggest_value(  trial: optuna.trial.Trial,
             return value
         
         elif len(value) == 3 and (isinstance(value[0], int) or isinstance(value[0], float)):
-            
             low, high = value[:2]
             step = None
             log = False

--- a/src/kgate/grid_search.py
+++ b/src/kgate/grid_search.py
@@ -1,18 +1,21 @@
+import logging
+from typing import Tuple, Any
+
 import optuna
+import pandas as pd
+
+from torchkge import KnowledgeGraph
+
 from .architect import Architect
 from .knowledgegraph import KnowledgeGraph
 from .utils import parse_config
-import pandas as pd
-from torchkge import KnowledgeGraph
-from typing import Tuple, Any
-import logging
 
 
 logging.captureWarnings(True)
 logging_level = logging.INFO
 logging.basicConfig(
-    level=logging_level,  
-    format="%(asctime)s - %(levelname)s - %(message)s" 
+    level = logging_level,  
+    format = "%(asctime)s - %(levelname)s - %(message)s" 
 )
 
 def run_grid_search(config_path: str,
@@ -28,26 +31,37 @@ def run_grid_search(config_path: str,
     To register a hyperparameter in the grid search optimization, set it as a list in the configuration.
 
     Not all hyperparameters can be evaluated. The full list is:
+    TODO.hyperparameters_list
+    
+    Arguments
+    ---------
+    number_of_trials: int, default to 10
+        TODO.What_that_argument_is_or_does
+    kg: Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph] or KnowledgeGraph, optional, default to None
+        Knowledge graph.
+    dataframe: pd.DataFrame, optional, default to None
+        TODO.What_that_argument_is_or_does
     
     Notes
     -----
     If the configuration file has no hyperparameter list, this function is effectively the same
     as running `Architect(config_path).train_model()`
+    
     """
-
     def objective(trial: optuna.trial.Trial):
-        config = parse_config(config_path = config_path,
-                            config_dictionnary = {})
+        config = parse_config(  config_path = config_path,
+                                config_dictionnary = {})
 
         config = {key: suggest_value(trial, key, config[key]) for key in config}
         
-        architect = Architect(kg = kg,
-                            df = dataframe,
-                            **config)
+        architect = Architect(  kg = kg,
+                                df = dataframe,
+                                **config)
 
         architect.train_model()
 
         result = architect.test()
+        
         return result["Global_metrics"]
 
     study = optuna.create_study(direction = "maximize",
@@ -61,22 +75,41 @@ def run_grid_search(config_path: str,
     for key, value in best_trial.params.items():
         logging.info("{}: {}".format(key, value))
 
-    
 
-def suggest_value(trial: optuna.trial.Trial,
-                value_name: str,
-                value: Any):
-    
+def suggest_value(  trial: optuna.trial.Trial,
+                    value_name: str,
+                    value: Any):
+    """
+        TODO.What_the_function_does_about_globally
+
+        Arguments
+        ---------
+        trial: optuna.trial.Trial
+            TODO.What_that_argument_is_or_does
+        value_name: str
+            TODO.What_that_argument_is_or_does
+        value: Any
+            TODO.What_that_argument_is_or_does
+
+        Returns
+        -------
+        suggested_value: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
     logging.info(value_name)
     logging.info(value)
     
     if value_name == "evaluation":
         return value
+    
     elif isinstance(value, dict):
         return {child_key: suggest_value(trial, child_key, value[child_key]) for child_key in value}
+    
     elif isinstance(value, list):
         if len(value) == 0:
             return value
+        
         elif len(value) == 3 and (isinstance(value[0], int) or isinstance(value[0], float)):
             
             low, high = value[:2]
@@ -84,9 +117,10 @@ def suggest_value(trial: optuna.trial.Trial,
             log = False
             if isinstance(value[2], bool):
                 log = True
+                
             else:
                 step = value[2]
-
+                
             match type(value[0]):
                 case "float":
                     return trial.suggest_float( name = value_name, 
@@ -95,12 +129,13 @@ def suggest_value(trial: optuna.trial.Trial,
                                                 step = step, 
                                                 log = log)
                 case "int":
-                    return trial.suggest_int(name = value_name,
-                                            low = low,
-                                            high = high,
-                                            step = step,
-                                            log = log)
+                    return trial.suggest_int(   name = value_name,
+                                                low = low,
+                                                high = high,
+                                                step = step,
+                                                log = log)
         else:
             return trial.suggest_categorical(name = value_name, choices = value)
+        
     else:
         return value

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -8,8 +8,6 @@ from torch.utils.data import DataLoader, Dataset
 
 from torch_geometric.utils import k_hop_subgraph
 
-import torchkge.inference as torchkge_inference
-
 from .encoders import DefaultEncoder, GNN
 from .decoders import TranslationalDecoder, BilinearDecoder, ConvolutionalDecoder
 from .knowledgegraph import KnowledgeGraph
@@ -71,7 +69,7 @@ class Inference_KG(Dataset):
 
 
 
-class EdgeInference(torchkge_inference.RelationInference):
+class EdgeInference:
     """
     Use trained embedding model to infer missing edges in triplets.
 
@@ -192,7 +190,7 @@ class EdgeInference(torchkge_inference.RelationInference):
 
 
 
-class NodeInference(torchkge_inference.EntityInference):
+class NodeInference:
     """
     Use trained embedding model to infer missing entities in triples.
 

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -121,10 +121,12 @@ class EdgeInference(torchkge_inference.RelationInference):
             Encoder model to embed the nodes. Deactivated with DefaultEncoder.
         decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
             Decoder model to evaluate.
-        node_embeddings: nn.ParameterList or nn.Embedding, keyword-only
-            A list containing all embeddings (values) for each node type (indices).
+        node_embeddings: nn.ParameterList, keyword-only
+            A list containing all embeddings for each node type.
+            keys: node type index
+            values: tensors of shape (node_count, embedding_dimensions)
         edge_embeddings: nn.Embedding, keyword-only
-            A tensor containing one embedding by edge type.
+            A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
         verbose: bool, default to True, keyword-only
             Indicate whether a progress bar should be displayed during evaluation.
 
@@ -245,9 +247,11 @@ class NodeInference(torchkge_inference.EntityInference):
         decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
             Decoder model to evaluate.
         node_embeddings: nn.ParameterList, keyword-only
-            A list containing all embeddings (values) for each node type (indices).
+            A list containing all embeddings for each node type.
+            keys: node type index
+            values: tensors of shape (node_count, embedding_dimensions)
         edge_embeddings: nn.Embedding, keyword-only
-            A tensor containing one embedding by edge type.
+            A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
         verbose: bool, default to True, keyword-only
             Indicate whether a progress bar should be displayed during
             evaluation.

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -1,47 +1,88 @@
-import torchkge.inference as torchkge_inference
-from torchkge.models import Model
+from typing import Dict, Literal
+
 from tqdm.autonotebook import tqdm
+
 from torch import tensor, nn, Tensor
 import torch
-from typing import Dict, Literal
+from torch.utils.data import DataLoader, Dataset
+
+from torch_geometric.utils import k_hop_subgraph
+
+import torchkge.inference as torchkge_inference
+from torchkge.models import Model
+
 from .utils import filter_scores
 from .encoders import DefaultEncoder, GNN
 from .knowledgegraph import KnowledgeGraph
-from torch.utils.data import DataLoader, Dataset
-from torch_geometric.utils import k_hop_subgraph
+
+
 
 class Inference_KG(Dataset):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    first_tensor_index: torch.Tensor
+        TODO.What_that_argument_is_or_does
+    second_tensor_index: torch.Tensor
+        TODO.What_that_argument_is_or_does
+
+    Attributes
+    ----------
+    first_tensor_index: torch.Tensor
+        TODO.What_that_variable_is_or_does
+    second_tensor_index: torch.Tensor
+        TODO.What_that_variable_is_or_does
+    
+    Raises
+    ------
+    error_name
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+
+    Notes
+    -----
+    TODO.explain_getitem
+    
+    """
     def __init__(self,
                 first_tensor_index: Tensor,
                 second_tensor_index: Tensor):
         
-        # Either both tensors nodes, or they are node and edge
+        # Either both tensors are nodes, or they are node and edge
         assert first_tensor_index.size() == second_tensor_index.size(), "Both index tensors must be of the same size for inference."
         self.first_tensor_index = first_tensor_index
         self.second_tensor_index = second_tensor_index
 
+
     def __len__(self):
         return self.first_tensor_index.size(0)
 
+
     def __getitem__(self, index: int):
         return (self.first_tensor_index[index], self.second_tensor_index[index])
+
 
 
 class EdgeInference(torchkge_inference.RelationInference):
     """
     Use trained embedding model to infer missing edges in triplets.
 
-    Parameters
-    ----------
-    kg: 
-        
+    Arguments
+    ---------
+    kg: KnowledgeGraph
+        Knowledge graph.
 
     Attributes
     ----------
-    kg: 
-        
-    """
+    kg: KnowledgeGraph
+        Knowledge graph.
 
+    """
     def __init__(self, kg: KnowledgeGraph):
         self.kg = kg
 
@@ -57,7 +98,42 @@ class EdgeInference(torchkge_inference.RelationInference):
                 edge_embeddings: nn.Embedding, 
                 verbose: bool = True,
                 **_):
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        head_index: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        tail_index: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        top_k: int, keyword-only
+            TODO.What_that_argument_is_or_does
+        batch_size: int, keyword-only
+            TODO.What_that_argument_is_or_does
+        encoder: DefaultEncoder or GNN, keyword-only
+            TODO.What_that_argument_is_or_does
+        decoder: torchkge.Model, keyword-only
+            TODO.What_that_argument_is_or_does
+        node_embeddings: nn.ParameterList or nn.Embedding, keyword-only
+            TODO.What_that_argument_is_or_does
+        edge_embeddings: nn.Embedding, keyword-only
+            TODO.What_that_argument_is_or_does
+        verbose: bool, default to True, keyword-only
+            TODO.What_that_argument_is_or_does
+
+        Returns
+        -------
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         with torch.no_grad():
             device = edge_embeddings.weight.device
 
@@ -92,8 +168,6 @@ class EdgeInference(torchkge_inference.RelationInference):
                     for node_type, index in input.mapping.items():
                         node_embeddings[index] = encoder_output[node_type]
 
-
-
                 head_embeddings, tail_embeddings, _, candidates = decoder.inference_prepare_candidates(head_index = head_index,
                                                                                                         tail_index = tail_index, 
                                                                                                         edge_index = tensor([]).long(),
@@ -111,35 +185,36 @@ class EdgeInference(torchkge_inference.RelationInference):
 
             return predictions.cpu(), scores.cpu()
 
+
+
 class NodeInference(torchkge_inference.EntityInference):
     """
     Use trained embedding model to infer missing entities in triples.
 
-        Parameters
-        ----------
-        kg: 
-
-
-        Attributes
-        ----------
-        model: torchkge.models.interfaces.Model
-            Embedding model inheriting from the right interface.
-        known_entities: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
-            List of the indices of known entities.
-        known_relations: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
-            List of the indices of known relations.
-        top_k: int
-            Indicates the number of top predictions to return.
-        missing: str
-            String indicating if the missing entities are the heads or the tails.
-        dictionary: dict, optional (default=None)
-            Dictionary of possible heads or tails (depending on the value of `missing`).
-            It is used to filter predictions that are known to be True in the training set
-            in order to return only new facts.
-        predictions: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.long`
-            List of the indices of predicted entities for each test fact.
-        scores: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.float`
-            List of the scores of resulting triples for each test fact.
+    Arguments
+    ---------
+    kg:
+    
+    Attributes
+    ----------
+    model: torchkge.models.interfaces.Model
+        Embedding model inheriting from the right interface.
+    known_entities: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
+        List of the indices of known entities.
+    known_relations: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
+        List of the indices of known relations.
+    top_k: int
+        Indicates the number of top predictions to return.
+    missing: str
+        String indicating if the missing entities are the heads or the tails.
+    dictionary: dict, optional (default=None)
+        Dictionary of possible heads or tails (depending on the value of `missing`).
+        It is used to filter predictions that are known to be True in the training set
+        in order to return only new facts.
+    predictions: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.long`
+        List of the indices of predicted entities for each test fact.
+    scores: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.float`
+        List of the scores of resulting triples for each test fact.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -156,8 +231,46 @@ class NodeInference(torchkge_inference.EntityInference):
                 decoder: Model,
                 node_embeddings: nn.ParameterList, 
                 edge_embeddings: nn.Embedding,
-                verbose:bool=True,
+                verbose: bool = True,
                 **_):
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        node_index: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        edge_list: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        top_k: int, keyword-only
+            TODO.What_that_argument_is_or_does
+        missing_triplet_part: Literal["head", "tail"], keyword-only
+            TODO.What_that_argument_is_or_does
+        batch_size: int, keyword-only
+            TODO.What_that_argument_is_or_does
+        encoder: DefaultEncoder or GNN, keyword-only
+            TODO.What_that_argument_is_or_does
+        decoder: torchkge.Model, keyword-only
+            TODO.What_that_argument_is_or_does
+        node_embeddings: nn.ParameterList, keyword-only
+            TODO.What_that_argument_is_or_does
+        edge_embeddings: nn.Embedding, keyword-only
+            TODO.What_that_argument_is_or_does
+        verbose: bool, default to True, keyword-only
+            TODO.What_that_argument_is_or_does
+
+        Returns
+        -------
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         with torch.no_grad():
             device = edge_embeddings.weight.device
 
@@ -169,7 +282,6 @@ class NodeInference(torchkge_inference.EntityInference):
                                     device = device).long()
             scores = torch.empty(size = (len(node_index), top_k),
                                 device = device).long()
-
 
             for i, batch in tqdm(enumerate(dataloader),
                                 total = len(dataloader),
@@ -199,17 +311,19 @@ class NodeInference(torchkge_inference.EntityInference):
             
                     for node_type, index in input.mapping.items():
                         node_embeddings[index] = encoder_output[node_type]
+                
                 else:
                     node_embeddings = node_embeddings[0][known_nodes]
 
                 if missing_triplet_part == "head":
-                    _, tail_embeddings, edge_embeddings, candidates = decoder.inference_prepare_candidates(head_index = tensor([], device=device).long(), 
+                    _, tail_embeddings, edge_embeddings, candidates = decoder.inference_prepare_candidates( head_index = tensor([], device=device).long(), 
                                                                                                             tail_index = known_nodes.to(device),
                                                                                                             edge_index = known_edges.to(device),
                                                                                                             node_embeddings = node_embeddings,
                                                                                                             edge_embeddings = edge_embeddings,
                                                                                                             node_inference = True)
                     batch_scores = decoder.inference_scoring_function(candidates, tail_embeddings, edge_embeddings)
+                
                 else:
                     head_embeddings, _, edge_embeddings, candidates = decoder.inference_prepare_candidates( head_index = known_nodes.to(device), 
                                                                                                             tail_index = tensor([], device=device).long(),

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -9,9 +9,9 @@ from torch.utils.data import DataLoader, Dataset
 from torch_geometric.utils import k_hop_subgraph
 
 import torchkge.inference as torchkge_inference
-from torchkge.models import Model
 
 from .encoders import DefaultEncoder, GNN
+from .decoders import TranslationalDecoder, BilinearDecoder, ConvolutionalDecoder
 from .knowledgegraph import KnowledgeGraph
 from .utils import filter_scores
 
@@ -95,7 +95,7 @@ class EdgeInference(torchkge_inference.RelationInference):
                 top_k: int,
                 batch_size: int,
                 encoder: DefaultEncoder | GNN,
-                decoder: Model,
+                decoder: TranslationalDecoder | BilinearDecoder | ConvolutionalDecoder,
                 node_embeddings: nn.ParameterList | nn.Embedding, 
                 edge_embeddings: nn.Embedding, 
                 verbose: bool = True,
@@ -218,7 +218,7 @@ class NodeInference(torchkge_inference.EntityInference):
                 missing_triplet_part: Literal["head", "tail"],
                 batch_size: int,
                 encoder: DefaultEncoder | GNN,
-                decoder: Model,
+                decoder: TranslationalDecoder | BilinearDecoder | ConvolutionalDecoder,
                 node_embeddings: nn.ParameterList, 
                 edge_embeddings: nn.Embedding,
                 verbose: bool = True,

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -41,8 +41,8 @@ class Inference_KG(Dataset):
     
     Raises
     ------
-    error_name
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    AssertionError
+        Index tensors are of different sizes.
 
     Notes
     -----
@@ -75,12 +75,12 @@ class EdgeInference(torchkge_inference.RelationInference):
     Arguments
     ---------
     kg: KnowledgeGraph
-        Knowledge graph.
+        Knowledge graph on which the inference will be done.
 
     Attributes
     ----------
     kg: KnowledgeGraph
-        Knowledge graph.
+        Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -120,17 +120,17 @@ class EdgeInference(torchkge_inference.RelationInference):
         decoder: torchkge.Model, keyword-only
             TODO.What_that_argument_is_or_does
         node_embeddings: nn.ParameterList or nn.Embedding, keyword-only
-            TODO.What_that_argument_is_or_does
+            A list containing all embeddings (values) for each node type (indices).
         edge_embeddings: nn.Embedding, keyword-only
-            TODO.What_that_argument_is_or_does
+            A tensor containing one embedding by edge type.
         verbose: bool, default to True, keyword-only
             TODO.What_that_argument_is_or_does
 
         Returns
         -------
-        result_name: TODO.type
+        predictions: TODO.type
             TODO.What_that_variable_is_or_does
-        result_name: TODO.type
+        scores: TODO.type
             TODO.What_that_variable_is_or_does
             
         """
@@ -193,27 +193,26 @@ class NodeInference(torchkge_inference.EntityInference):
 
     Arguments
     ---------
-    kg:
+    kg: KnowledgeGraph
+        Knowledge graph on which the inference will be done.
     
     Attributes
     ----------
-    model: torchkge.models.interfaces.Model
-        Embedding model inheriting from the right interface.
-    known_entities: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
-        List of the indices of known entities.
-    known_relations: `torch.Tensor`, shape: (n_facts), dtype: `torch.long`
-        List of the indices of known relations.
-    top_k: int
+    known_nodes: torch.Tensor, shape: (n_facts), dtype: torch.long
+        List of the indices of known nodes.
+    known_edges: torch.Tensor, shape: (n_facts), dtype: torch.long
+        List of the indices of known edges.
+    top_k: int, keyword-only
         Indicates the number of top predictions to return.
-    missing: str
+    missing_triplet_part: Literal["head", "tail"], keyword-only
         String indicating if the missing entities are the heads or the tails.
     dictionary: dict, optional (default=None)
         Dictionary of possible heads or tails (depending on the value of `missing`).
         It is used to filter predictions that are known to be True in the training set
         in order to return only new facts.
-    predictions: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.long`
+    predictions: torch.Tensor, shape: (n_facts, self.top_k), dtype: `torch.long`
         List of the indices of predicted entities for each test fact.
-    scores: `torch.Tensor`, shape: (n_facts, self.top_k), dtype: `torch.float`
+    scores: torch.Tensor, shape: (n_facts, self.top_k), dtype: `torch.float`
         List of the scores of resulting triples for each test fact.
 
     """
@@ -251,23 +250,24 @@ class NodeInference(torchkge_inference.EntityInference):
         missing_triplet_part: Literal["head", "tail"], keyword-only
             TODO.What_that_argument_is_or_does
         batch_size: int, keyword-only
-            TODO.What_that_argument_is_or_does
+            Size of the current batch.
         encoder: DefaultEncoder or GNN, keyword-only
-            TODO.What_that_argument_is_or_does
-        decoder: torchkge.Model, keyword-only
-            TODO.What_that_argument_is_or_does
+            Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+        decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+            Decoder model to evaluate.
         node_embeddings: nn.ParameterList, keyword-only
-            TODO.What_that_argument_is_or_does
+            A list containing all embeddings (values) for each node type (indices).
         edge_embeddings: nn.Embedding, keyword-only
-            TODO.What_that_argument_is_or_does
+            A tensor containing one embedding by edge type.
         verbose: bool, default to True, keyword-only
-            TODO.What_that_argument_is_or_does
+            Indicates whether a progress bar should be displayed during
+            evaluation.
 
         Returns
         -------
-        result_name: TODO.type
+        predictions: TODO.type
             TODO.What_that_variable_is_or_does
-        result_name: TODO.type
+        scores: TODO.type
             TODO.What_that_variable_is_or_does
             
         """

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -41,7 +41,7 @@ class Inference_KG(Dataset):
     Raises
     ------
     AssertionError
-        Index tensors are of different sizes.
+        Both index tensors must be of the same size.
 
     Notes
     -----

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -24,8 +24,8 @@ from torch.types import Number
 from torch_geometric.data import HeteroData
 
 import torchkge
-from torchkge.utils.operations import get_dictionaries
 
+from .utils import get_dictionary_mapping
 
 logging.basicConfig(
     level = logging.INFO,  
@@ -209,9 +209,9 @@ class KnowledgeGraph(Dataset):
 
         self.triplet_types: List[Tuple[str, str, str]] = triplet_types or []
 
-        self.node_to_index = node_to_index or get_dictionaries(dataframe, ent = True)
+        self.node_to_index = node_to_index or get_dictionary_mapping(dataframe, nodes = True)
         self.node_type_to_index: Dict[str, int] = node_type_to_index or {"Node": 0}
-        self.edge_to_index = edge_to_index or get_dictionaries(dataframe, ent = False)
+        self.edge_to_index = edge_to_index or get_dictionary_mapping(dataframe, nodes = False)
 
         self.node_count = max(self.node_to_index.values()) + 1
         self.edge_count = max(self.edge_to_index.values()) + 1

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -329,7 +329,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: torch.Tensor
+        TODO.result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -343,7 +343,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: torch.Tensor
+        TODO.result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -357,7 +357,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: torch.Tensor
+        TODO.result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -371,7 +371,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: torch.Tensor
+        TODO.result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -385,7 +385,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: torch.Tensor
+        TODO.result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -416,7 +416,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        result_name: pd.DataFrame
+        TODO.result_name: pd.DataFrame
             TODO.What_that_variable_is_or_does
         
         """
@@ -438,16 +438,23 @@ class KnowledgeGraph(Dataset):
         If that is not the case, functions using identities might have unexpected behavior. To get the dataframe corresponding to the current
         identity, call the `identity` property.
         
-        Argument
-        --------
-            new_identity: str
-                The name of the new identity, which must exist in the metadata.
+        Arguments
+        ---------
+        new_identity: str
+            The name of the new identity, which must exist in the metadata.
         
-        Warning
-        -------
-            If all values are not unique in the new identity, a warning will be issued.
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        
+        Warns
+        -----
+        If all values are not unique in the new identity, a warning will be issued.
             
-            """
+        """
         assert self.metadata is not None, "You need to add metadata in order to set an identity."
         assert new_identity in self.metadata, f"The given identity is not a valid metadata name. Valid names are: {self.metadata.columns}."
 
@@ -464,10 +471,19 @@ class KnowledgeGraph(Dataset):
         If there is already a metadata dataframe associated with the knowledge graph, the new one must have an identical "id" column to be valid.
         If there is no metadata, then the given dataframe must contain at least the columns "id" and "type".
 
-        Argument
-        --------
-            metadata: pd.DataFrame
-                The metadata dataframe to associate to the knowledge graph.
+        Arguments
+        ---------
+        metadata: pd.DataFrame
+            The metadata dataframe to associate to the knowledge graph.
+        
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
         
         """
         if self.metadata is None:
@@ -482,6 +498,11 @@ class KnowledgeGraph(Dataset):
     def get_dataframe(self):
         """
         Returns a Pandas DataFrame with columns ['head', 'tail', 'edge'].
+
+        Returns
+        -------
+        dataframe: pd.DataFrame
+            TODO.What_that_variable_is_or_does
         
         """
         index_to_node = {value: key for key, value in self.node_to_index.items()}
@@ -497,12 +518,39 @@ class KnowledgeGraph(Dataset):
         dataframe['edge'] = dataframe['edge'].apply(lambda x: index_to_edge[x])
 
         return dataframe
+    
 
     def split_kg(self,
-                split_proportions: Tuple[float, float, float] = (0.8,0.1,0.1), 
+                split_proportions: Tuple[float, float, float] = (0.8, 0.1, 0.1), 
                 sizes: Tuple[int, int, int] | None = None
                 ) -> Tuple[Self, Self, Self]:
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        split_proportions: Tuple[float, float, float], default to (0.8, 0.1, 0.1)
+            TODO.What_that_argument_is_or_does
+        sizes: Tuple[int, int, int], optional, default to None
+            TODO.What_that_argument_is_or_does
+
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+
+        Returns
+        -------
+        TODO.result_name: Tuple[Self, Self, Self]
+            TODO.What_that_variable_is_or_does
+            
+        """
         if sizes is not None:
             assert sum(sizes) == self.triplet_count, "The sum of provided sizes must match the number of triplets."
             
@@ -546,7 +594,37 @@ class KnowledgeGraph(Dataset):
             
             
     def get_mask(self, split_proportions):
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        split_proportions: TODO.type
+            TODO.What_that_argument_is_or_does
+
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+
+        Returns
+        -------
+        TODO.result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+        TODO.result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+        TODO.result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         unique_edges, edge_counts = self.edge_indices.unique(return_counts = True)
         unique_nodes = np.arange(self.node_count)
 
@@ -572,7 +650,7 @@ class KnowledgeGraph(Dataset):
         unique_nodes = cat([self.head_indices[train_mask], self.tail_indices[train_mask]]).unique()
         if len(unique_nodes) < self.node_count:
             missing_nodes = tensor(list(set(unique_nodes.tolist()) - set(unique_nodes.tolist())),
-                                    dtype=torch.long)
+                                    dtype = torch.long)
             for node in missing_nodes:
                 mask_subset = ((self.head_indices == node) |
                                 (self.tail_indices == node)).nonzero(as_tuple = False)[:, 0]
@@ -586,6 +664,7 @@ class KnowledgeGraph(Dataset):
                 validation_mask[mask_subset[random[:train_set_size]]] = False
         
         assert not (train_mask & validation_mask).any().item()
+        
         return train_mask, validation_mask, ~(train_mask | validation_mask)
 
 
@@ -594,10 +673,10 @@ class KnowledgeGraph(Dataset):
                     ) -> Self:
         """
         Keeps only the specified triplets in the knowledge graph and returns a new
-        KnowledgeGraph instance with these triplets. Updates the dictionnary of facts.
+        KnowledgeGraph instance with these triplets. Updates the dictionnary of facts (TODO).
 
-        Parameters
-        ----------
+        Arguments
+        ---------
         indices_to_keep : list or torch.Tensor
             Indices of triplets to keep in the knowledge graph.
 
@@ -630,8 +709,8 @@ class KnowledgeGraph(Dataset):
         Removes specified triplets from the knowledge graph and returns a new
         KnowledgeGraph instance without these triplets.
 
-        Parameters
-        ----------
+        Arguments
+        ---------
         indices_to_remove : list or torch.Tensor
             Indices of triplets to remove from the knowledge graph.
 
@@ -655,16 +734,26 @@ class KnowledgeGraph(Dataset):
             removed_triplets = removed_triplets
         )
     
+    
     def add_triplets(self,
                     new_triplets: torch.Tensor
                     ) -> Self:
         """
         Adds new triplets to the Knowledge Graph
 
-        Parameters
-        ----------
+        Arguments
+        ---------
         new_triplets : torch.Tensor
-            Tensor of shape (4, n) where each column represent a triplet (head_index, tail_index, edge_index, triplet_type).
+            Tensor of shape (4, n) where each column represents a triplet (head_index, tail_index, edge_index, triplet_type).
+
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        ValueError
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        ValueError
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
 
         Returns
         -------
@@ -702,18 +791,20 @@ class KnowledgeGraph(Dataset):
         """
         Adds reverse triplets for the specified undirected edges in the knowledge graph.
         Updates head_index, tail_index, edges with the reverse triplets, and updates the dictionaries to include
-        both original and reverse facts in all directions.
+        both original and reverse facts (TODO) in all directions.
 
-        Parameters
+        Arguments
         ----------
-        undirected_edges: list
+        undirected_edges: List[int]
             List of undirected edges for which reverse triplets should be added.
 
         Returns
         -------
-        KnowledgeGraph, list
+        KnowledgeGraph: Self (TODO?)
             The updated KnowledgeGraph with the dictionaries and tensors modified,
             and a list of pairs (old edge ID, new reverse edge ID).
+        reverse_list: List[int]
+            TODO.What_that_variable_is_or_does
             
         """
         index_to_edge = {value: key for key, value in self.edge_to_index.items()}
@@ -782,8 +873,10 @@ class KnowledgeGraph(Dataset):
         This function processes each edge separately, identifies unique triplets based on head and tail indices,
         and retains only the unique triplets by filtering out duplicates.
 
-        Returns:
-        - KnowledgeGraph: A new instance of the KnowledgeGraph containing only unique triplets.
+        Returns
+        -------
+        TODO.result_name: TODO.type
+            A new instance of the KnowledgeGraph containing only unique triplets.
         
         The function also updates a dictionary `pair_dictionnary` which holds pairs of head and tail indices for each edge
         along with their original indices in the dataset.
@@ -842,7 +935,31 @@ class KnowledgeGraph(Dataset):
                     edge_type_index: int,
                     type: str = "head_tail"
                     ) -> Set[Tuple[Number, Number]]:
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        edge_type_index: int
+            TODO.What_that_argument_is_or_does
+        type: str, default to "head_tail"
+            TODO.What_that_argument_is_or_does
+
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+
+        Returns
+        -------
+        TODO.result_name: Set[Tuple[Number, Number]
+            TODO.What_that_variable_is_or_does
+            
+        """
         mask = (self.edge_indices == edge_type_index)
 
         if type == "head_tail":
@@ -870,26 +987,27 @@ class KnowledgeGraph(Dataset):
         ----------
         * Farahnaz Akrami, Mohammed Samiul Saeef, Quingheng Zhang.
         `Realistic Re-evaluation of Knowledge Graph Completion Methods:
-        An Experimental Study. <https://arxiv.org/pdf/2003.08001.pdf>`_
+        An Experimental Study.`
+        <https://arxiv.org/pdf/2003.08001.pdf>
         SIGMOD’20, June 14–19, 2020, Portland, OR, USA
 
-        Parameters
-        ----------
-        theta_first_edge_type: float
+        Arguments
+        ---------
+        theta_first_edge_type: float, default to 0.8
             First threshold (see paper).
-        theta_second_edge_type: float
+        theta_second_edge_type: float, default to 0.8
             Second threshold (see paper).
-        reverse_edges_list: list
+        reverse_edges_list: List[int], optional, default to None
             List of known reverse edges.
 
         Returns
         -------
-        duplicates: list
+        duplicates: List[Tuple[int, int]]
             List of pairs giving duplicate edges.
-        reverse_duplicates: list
+        reverse_duplicates: List[Tuple[int, int]]
             List of pairs giving reverse duplicate edges.
-        """
         
+        """
         if reverse_edges_list is None:
             reverse_edges_list = []
 
@@ -955,19 +1073,19 @@ class KnowledgeGraph(Dataset):
         ----------
         * Farahnaz Akrami, Mohammed Samiul Saeef, Quingheng Zhang.
         `Realistic Re-evaluation of Knowledge Graph Completion Methods: An
-        Experimental Study. <https://arxiv.org/pdf/2003.08001.pdf>`_
+        Experimental Study.`
+        <https://arxiv.org/pdf/2003.08001.pdf>
         SIGMOD’20, June 14–19, 2020, Portland, OR, USA
 
-        Parameters
-        ----------
-        kg: torchkge.data_structures.KnowledgeGraph
-        theta: float
+        Arguments
+        ---------
+        theta: float, default to 0.8
             Threshold used to compute the cartesian product edges.
 
         Returns
         -------
-        selected_edges: list
-            List of edges index that are cartesian product edges
+        selected_edges: List[int]
+            List of edge indices that are cartesian product edges
             (see paper for details).
 
         """
@@ -1000,7 +1118,31 @@ class KnowledgeGraph(Dataset):
                             data: Tensor,
                             node_embedding: nn.ParameterList
                             ) -> EncoderInput:
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        data: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        node_embedding: nn.ParameterList
+            TODO.What_that_argument_is_or_does
+
+        Raises
+        ------
+        TODO.error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+
+        Returns
+        -------
+        TODO.result_name: EncoderInput
+            TODO.What_that_variable_is_or_does
+            
+        """
         assert data.device == node_embedding[0].device
         device = data.device
 
@@ -1052,6 +1194,24 @@ class KnowledgeGraph(Dataset):
     def flatten_embeddings( self,
                             node_embeddings: nn.ParameterList
                             ) -> Tensor:
+        """
+        TODO.What_the_function_does_about_globally
+
+        References
+        ----------
+        TODO
+
+        Arguments
+        ---------
+        node_embeddings: nn.ParameterList
+            TODO.What_that_argument_is_or_does
+
+        Returns
+        -------
+        embeddings: torch.Tensor
+            TODO.What_that_variable_is_or_does
+            
+        """
         embeddings: torch.Tensor = torch.zeros((self.node_count, node_embeddings[0].size(1)),
                                                 device = node_embeddings[0].device,
                                                 dtype = torch.float)
@@ -1064,11 +1224,29 @@ class KnowledgeGraph(Dataset):
 
 
     def clean(self):
+        """
+        TODO.What_the_function_does_about_globally
+        
+        """
         self.triplet_types = [triplet for triplet in self.triplet_types if triplet[1] != "self"]
 
 
     @staticmethod
     def from_hetero_data(hetero_data: HeteroData):
+        """
+        Create a new KGATE KnowledgeGraph instance from the PyTorch Geometric HeteroData object.
+        
+        Arguments
+        ---------
+        hetero_data : HeteroData
+            The knowledge graph as a PyTorch Geometric HeteroData object.
+
+        Returns
+        -------
+        KnowledgeGraph
+            The knowledge graph as a KGATE KnowledgeGraph object.
+            
+        """
         # TODO
         pass
 
@@ -1078,13 +1256,13 @@ class KnowledgeGraph(Dataset):
                         metadata: pd.DataFrame | None = None
                         ) -> Self:
         """
-        Create a new KGATE Knowledge Graph instance from the torchKGE format.
+        Create a new KGATE KnowledgeGraph instance from the TorchKGE KnowledgeGraph object.
         
-        Parameters
-        ----------
+        Arguments
+        ---------
         torchkge_kg : torchKGE.KnowledgeGraph
             The knowledge graph as a torchKGE KnowledgeGraph object.
-        metadata : pd.DataFrame
+        metadata : pd.DataFrame, optional
             The metadata of the knowledge graph, with at least the columns "id" and "type".
 
         Returns
@@ -1098,7 +1276,7 @@ class KnowledgeGraph(Dataset):
                                         torchkge_kg.tail_idx,
                                         torchkge_kg.relations,
                                         tensor(0).repeat(torchkge_kg.n_facts)],
-                                        dim=0).long()
+                                        dim = 0).long()
             node_type_to_index = {"Node":0}
             triplet_types = [("Node", edge, "Node")
                             for edge

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -333,7 +333,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: torch.Tensor
+        result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -347,7 +347,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: torch.Tensor
+        result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -361,7 +361,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: torch.Tensor
+        result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -375,7 +375,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: torch.Tensor
+        result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -389,7 +389,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: torch.Tensor
+        result_name: torch.Tensor
             TODO.What_that_variable_is_or_does
             
         """
@@ -420,7 +420,7 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: pd.DataFrame
+        result_name: pd.DataFrame
             TODO.What_that_variable_is_or_does
         
         """

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -44,7 +44,9 @@ class EncoderInput:
     Arguments
     ---------
     x_dict: Dict[str, Tensor]
-        TODO.What_that_argument_is_or_does
+        Key (str): node type
+        Value (Tensor): [node_count for the node_type, embedding_dimension]
+        PyTorch Geometric equivalent to node_embeddings.
     edge_list: Dict[str, Tensor]
         TODO.What_that_argument_is_or_does
     mapping: Dict[str, Tensor]
@@ -53,7 +55,9 @@ class EncoderInput:
     Attributes
     ----------
     x_dict: Dict[str, Tensor]
-        TODO.What_that_variable_is_or_does
+        Key (str): node type
+        Value (Tensor): [node_count for the node_type, embedding_dimension]
+        PyTorch Geometric equivalent to node_embeddings.
     edge_list: Dict[str, Tensor]
         TODO.What_that_variable_is_or_does
     mapping: Dict[str, Tensor]
@@ -85,17 +89,17 @@ class EncoderInput:
         ])
 
         message = f"""{self.__class__.__name__} (
-    x_dict: {{
-        {x_repr}
-    }}
+                    x_dict: {{
+                        {x_repr}
+                    }}
 
-    edge_index: {{
-        {edge_repr}
-    }}
+                    edge_index: {{
+                        {edge_repr}
+                    }}
 
-    mapping: {{
-        {mapping_repr}
-    }})"""
+                    mapping: {{
+                        {mapping_repr}
+                    }})"""
 
         return message
 
@@ -113,10 +117,10 @@ class KnowledgeGraph(Dataset):
     ---------
     dataframe: pd.DataFrame , default to None
         TODO.What_that_argument_is_or_does
-    graphindices: torch.Tensor, default to None
-        TODO.What_that_argument_is_or_does
+    graphindices: torch.Tensor, shape: [4, triplet_count], default to None
+        Tensor of containing every true triplet in the knowledge graph.
     metadata: pd.DataFrame, default to None
-        TODO.What_that_argument_is_or_does
+        The metadata dataframe to associate to the knowledge graph.
     triplet_types: List[Tuple[str, str, str]], default to None
         TODO.What_that_argument_is_or_does
     node_to_index: Dict[str, int], default to None
@@ -130,10 +134,10 @@ class KnowledgeGraph(Dataset):
 
     Attributes
     ----------
-    graphindices: torch.Tensor
-        TODO.What_that_variable_is_or_does
+    graphindices: torch.Tensor, shape: [4, triplet_count], default to None
+        Tensor of containing every true triplet in the knowledge graph.
     metadata: pd.DataFrame, default to None
-        TODO.What_that_variable_is_or_does
+        The metadata dataframe to associate to the knowledge graph.
     triplet_types: List[Tuple[str, str, str]]
         TODO.What_that_variable_is_or_does
     node_to_index: Dict[str, int]
@@ -162,9 +166,9 @@ class KnowledgeGraph(Dataset):
     ValueError
         If `dataframe` is not given, `graphindices`, `triplet_types`, `node_to_index`, `edge_to_index` and `node_type_to_index` must be provided.
     ValueError
-        The `graphindices` parameter must be a 2D tensor of size [4, triplet_count].
+        The `graphindices` parameter must be a 2D tensor of shape [4, triplet_count].
     ValueError
-        The `removed_triplets` parameter must be a 2D tensor of size [4, triplet_count].
+        The `removed_triplets` parameter must be a 2D tensor of shape [4, triplet_count].
     
     """
     def __init__(self,
@@ -445,10 +449,10 @@ class KnowledgeGraph(Dataset):
         
         Raises
         ------
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        AssertionError #1
+            Metadata is required to set an identity.
+        AssertionError #2
+            The given identity is not a valid data name.
         
         Warns
         -----
@@ -478,12 +482,12 @@ class KnowledgeGraph(Dataset):
         
         Raises
         ------
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        AssertionError #1
+            The metadata dataframe must have at least the columns `type` and `id`.
+        AssertionError #2
+            The number of rows in the metadata dataframe must match the number of nodes in the graph.
+        AssertionError #3
+            The metadata dataframe must have an `id` column identical to the existing metadata.
         
         """
         if self.metadata is None:
@@ -547,8 +551,8 @@ class KnowledgeGraph(Dataset):
 
         Returns
         -------
-        TODO.result_name: Tuple[Self, Self, Self]
-            TODO.What_that_variable_is_or_does
+        kgs: Tuple[Self, Self, Self]
+            3 new instances of KnowledgeGraph: train, validation, test.
             
         """
         if sizes is not None:
@@ -608,11 +612,11 @@ class KnowledgeGraph(Dataset):
 
         Raises
         ------
-        TODO.error_name
+        AssertionError #1
             TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        TODO.error_name
+        AssertionError #2
             TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        TODO.error_name
+        AssertionError #3
             TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
 
         Returns
@@ -677,7 +681,7 @@ class KnowledgeGraph(Dataset):
 
         Arguments
         ---------
-        indices_to_keep : list or torch.Tensor
+        indices_to_keep : List[int] or torch.Tensor
             Indices of triplets to keep in the knowledge graph.
 
         Returns
@@ -711,7 +715,7 @@ class KnowledgeGraph(Dataset):
 
         Arguments
         ---------
-        indices_to_remove : list or torch.Tensor
+        indices_to_remove : List[int] or torch.Tensor
             Indices of triplets to remove from the knowledge graph.
 
         Returns
@@ -744,16 +748,16 @@ class KnowledgeGraph(Dataset):
         Arguments
         ---------
         new_triplets : torch.Tensor
-            Tensor of shape (4, n) where each column represents a triplet (head_index, tail_index, edge_index, triplet_type).
+            Tensor of shape [4, n] where each column represents a triplet (head_index, tail_index, edge_index, triplet_type).
 
         Raises
         ------
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        ValueError
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        ValueError
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        AssertionError
+            The tensor new_triplets must have shape [4, n].
+        ValueError #1
+            The maximum node index must not be superior to the number of nodes.
+        ValueError #2
+            The maximum triplet index must not be superior to the number of edges.
 
         Returns
         -------
@@ -783,7 +787,7 @@ class KnowledgeGraph(Dataset):
             node_type_to_index = self.node_type_to_index,
             removed_triplets = self.removed_triplets
         )
-        
+    
 
     def add_reverse_edges(self,
                         undirected_edges: List[int]
@@ -791,7 +795,7 @@ class KnowledgeGraph(Dataset):
         """
         Adds reverse triplets for the specified undirected edges in the knowledge graph.
         Updates head_index, tail_index, edges with the reverse triplets, and updates the dictionaries to include
-        both original and reverse facts (TODO) in all directions.
+        both original and reverse triplets in all directions.
 
         Arguments
         ----------
@@ -872,14 +876,14 @@ class KnowledgeGraph(Dataset):
 
         This function processes each edge separately, identifies unique triplets based on head and tail indices,
         and retains only the unique triplets by filtering out duplicates.
-
-        Returns
-        -------
-        TODO.result_name: TODO.type
-            A new instance of the KnowledgeGraph containing only unique triplets.
         
         The function also updates a dictionary `pair_dictionnary` which holds pairs of head and tail indices for each edge
         along with their original indices in the dataset.
+
+        Returns
+        -------
+        kg: KnowledgeGraph
+            A new instance of the KnowledgeGraph containing only unique triplets.
 
         """
         pair_dictionnary = {}  # Dictionary to store pairs for each edge
@@ -951,8 +955,8 @@ class KnowledgeGraph(Dataset):
 
         Raises
         ------
-        TODO.error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        AssertionError #1
+            If the type is not "head_tail" then it must be "tail_head".
 
         Returns
         -------
@@ -1130,18 +1134,20 @@ class KnowledgeGraph(Dataset):
         data: torch.Tensor
             TODO.What_that_argument_is_or_does
         node_embedding: nn.ParameterList
-            TODO.What_that_argument_is_or_does
+            A list containing all embeddings for each node type.
+            keys: node type index
+            values: tensors of shape (node_count, embedding_dimensions)
 
         Raises
         ------
-        TODO.error_name
+        AssertionError
             TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
 
         Returns
         -------
         TODO.result_name: EncoderInput
             TODO.What_that_variable_is_or_does
-            
+        
         """
         assert data.device == node_embedding[0].device
         device = data.device

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -1203,8 +1203,10 @@ class KnowledgeGraph(Dataset):
 
         Arguments
         ---------
-        node_embeddings: nn.ParameterList
-            TODO.What_that_argument_is_or_does
+        node_embeddings: nn.ParameterList, keyword-only
+            A list containing all embeddings for each node type.
+            keys: node type index
+            values: tensors of shape (node_count, embedding_dimensions)
 
         Returns
         -------

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -1,4 +1,7 @@
-"""Knowledge Graph preprocessing functions to run before any training procedure."""
+"""
+Knowledge Graph preprocessing functions to run before any training procedure.
+
+"""
 
 import logging
 import pickle

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -1,8 +1,8 @@
 """Knowledge Graph preprocessing functions to run before any training procedure."""
 
-from pathlib import Path
 import logging
 import pickle
+from pathlib import Path
 from typing import Tuple, List, Set
 
 import pandas as pd
@@ -12,10 +12,12 @@ from torch import cat
 
 import torchkge
 
-from .utils import set_random_seeds, compute_triplet_proportions
 from .knowledgegraph import KnowledgeGraph
+from .utils import set_random_seeds, compute_triplet_proportions
+
 
 SUPPORTED_SEPARATORS = [",","\t",";"]
+
 
 def prepare_knowledge_graph(config: dict, 
                             kg: KnowledgeGraph | None, 
@@ -37,19 +39,32 @@ def prepare_knowledge_graph(config: dict,
     ---------
     config: dict
         The full configuration, usually parsed from the KGATE configuration file.
-    kg: torchKGE.KnowledgeGraph
+    kg: KnowledgeGraph
         The knowledge graph as a single object of class KnowledgeGraph or inheriting the class (KnowledgeGraph inherits the class)
     dataframe: pd.DataFrame
         The knowledge graph as a pandas DataFrame.
     metadata: pd.DataFrame
         TODO: description here
+
+    Raises
+    ------
+    ValueError
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    ValueError
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    NotImplementedError
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
         
     Returns
     -------
-    kg_train, kg_validation, kg_test: KnowledgeGraph
-        A tuple containing the preprocessed and split knowledge graph.
+    kg_train: KnowledgeGraph
+        Subpart of the preprocessed and split knowledge graph, for training.
+    kg_validation: KnowledgeGraph
+        Subpart of the preprocessed and split knowledge graph, for validation.
+    kg_test: KnowledgeGraph
+        Subpart of the preprocessed and split knowledge graph, for test.
         
-        """
+    """
     # Load knowledge graph
     if kg is None and dataframe is None:
         input_file = config["kg_csv"]
@@ -105,14 +120,13 @@ def save_knowledge_graph(config: dict,
     config: dict
         The full configuration, usually parsed from the KGATE configuration file.
     kg_train: KnowledgeGraph
-        The training knowledge graph.
+        The training subpart of the knowledge graph.
     kg_validation: KnowledgeGraph
-        The validation knowledge graph.
+        The validation subpart of the knowledge graph.
     kg_test: KnowledgeGraph
-        The testing knowledge graph.
+        The testing subpart of the knowledge graph.
         
     """
-
     if config["kg_pkl"] == "":
         pickle_filename = Path(config["output_directory"], "kg.pkl")
     else:
@@ -127,6 +141,16 @@ def save_knowledge_graph(config: dict,
 def load_knowledge_graph(pickle_filename: Path):
     """
     Load the knowledge graph from a pickle file.
+        
+    Arguments
+    ---------
+    pickle_filename: Path
+        TODO.What_that_argument_is_or_does
+        
+    Returns
+    -------
+    kg_train, kg_validation, kg_test: KnowledgeGraph
+        A tuple containing the preprocessed and split knowledge graph.
     
     """
     with open(pickle_filename, "rb") as file:
@@ -142,6 +166,27 @@ def clean_knowledge_graph(  kg: KnowledgeGraph,
                             ) -> Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph]:
     """
     Clean and prepare the knowledge graph according to the configuration.
+        
+    Arguments
+    ---------
+    kg: KnowledgeGraph
+        TODO.What_that_argument_is_or_does
+    config: dict
+        TODO.What_that_argument_is_or_does
+    
+    Raises
+    ------
+    ValueError
+        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        
+    Returns
+    -------
+    new_kg_train: KnowledgeGraph
+        Cleaned training knowledge graph.
+    new_kg_validation: KnowledgeGraph
+        Cleaned validation knowledge graph.
+    new_kg_test: KnowledgeGraph
+        Cleaned test knowledge graph.
     
     """
     set_random_seeds(config["seed"])
@@ -226,8 +271,8 @@ def verify_node_coverage(kg_train: KnowledgeGraph,
     """
     Verify that all nodes in the full knowledge graph are represented in the training set.
 
-    Parameters
-    ----------
+    Arguments
+    ---------
     kg_train: KnowledgeGraph
         The training knowledge graph.
     kg_full: KnowledgeGraph
@@ -235,8 +280,7 @@ def verify_node_coverage(kg_train: KnowledgeGraph,
 
     Returns
     -------
-    tuple
-        (bool, list)
+    TODO.result_name: Tuple[bool, List[str]]
         A tuple where the first element is True if all nodes in the full knowledge graph are present in the training 
         knowledge graph, and the second element is a list of missing nodes (names) if any are missing.
     
@@ -255,6 +299,7 @@ def verify_node_coverage(kg_train: KnowledgeGraph,
         # Get missing node names from their indices
         missing_node_names = [index_to_node[index] for index in missing_node_indices if index in index_to_node]
         return False, missing_node_names
+    
     else:
         return True, []
     
@@ -267,22 +312,22 @@ def ensure_node_coverage(kg_train: KnowledgeGraph,
     Ensure that all nodes in kg_train.node_to_index are present in kg_train as head or tail.
     If an node is missing, move a triplet involving that node from kg_validation or kg_test to kg_train.
 
-    Parameters
-    ----------
-    kg_train: torchkge.data_structures.KnowledgeGraph
+    Arguments
+    ---------
+    kg_train: KnowledgeGraph
         The training knowledge graph to ensure node coverage.
-    kg_validation: torchkge.data_structures.KnowledgeGraph
+    kg_validation: KnowledgeGraph
         The validation knowledge graph from which to move triplets if needed.
-    kg_test: torchkge.data_structures.KnowledgeGraph
+    kg_test: KnowledgeGraph
         The test knowledge graph from which to move triplets if needed.
 
     Returns
     -------
-    kg_train: torchkge.data_structures.KnowledgeGraph
+    kg_train: KnowledgeGraph
         The updated training knowledge graph with all nodes covered.
-    kg_validation: torchkge.data_structures.KnowledgeGraph
+    kg_validation: KnowledgeGraph
         The updated validation knowledge graph.
-    kg_test: torchkge.data_structures.KnowledgeGraph
+    kg_test: KnowledgeGraph
         The updated test knowledge graph.
     
     """
@@ -334,6 +379,7 @@ def ensure_node_coverage(kg_train: KnowledgeGraph,
             nodes_in_triplets = set(triplets[0].tolist() + triplets[1].tolist())
             remaining_nodes = nodes - set(nodes_in_triplets)
             return remaining_nodes
+        
         return nodes
 
     # Move triplets from kg_validation then from kg_test
@@ -354,20 +400,21 @@ def clean_datasets( kg_train: KnowledgeGraph,
                     known_reverses: List[Tuple[int, int]]
                     ) -> KnowledgeGraph:
     """
-    Clean the training KG by removing reverse duplicate triples contained in KG2 (test or val KG).
+    Clean the train knowledge graph by removing reverse duplicate triplets contained
+    in the second knowledge graph (test or validation).
 
-    Parameters
-    ----------
-    kg_train: torchkge.data_structures.KnowledgeGraph
+    Arguments
+    ---------
+    kg_train: KnowledgeGraph
         The training knowledge graph.
-    kg_second: torchkge.data_structures.KnowledgeGraph
+    kg_second: KnowledgeGraph
         The second knowledge graph, test or validation.
-    known_reverses: list of tuples
-        Each tuple contains two edges (first_edge_type, second_edge_type) that are known reverse relations.
+    known_reverses: List[Tuple[int, int]]
+        Each tuple contains two edges (first_edge_type, second_edge_type) that are known reverse edges.
 
     Returns
     -------
-    torchkge.data_structures.KnowledgeGraph
+    kg_train: KnowledgeGraph
         The cleaned train knowledge graph.
         
     """
@@ -390,13 +437,13 @@ def clean_datasets( kg_train: KnowledgeGraph,
                                             if (head.item(), tail.item()) in first_edge_type_pairs_in_kg_second
                                             and kg_train.edge_indices[edge_index].item() == second_edge_type])
         
-        # Remove those (head, tail) pairs from kg_train
-        kg_train = kg_train.remove_triplets(torch.tensor(indices_to_remove_kg_train, dtype=torch.long))
+        # Remove these (head, tail) pairs from kg_train
+        kg_train = kg_train.remove_triplets(torch.tensor(indices_to_remove_kg_train, dtype = torch.long))
 
         logging.info(f"Found {len(indices_to_remove_kg_train)} triplets to remove for edge {second_edge_type} with reverse {first_edge_type}.")
 
         # Get (head, tail) pairs, in kg_second, that are related by second_edge_type
-        second_edge_type_pairs_in_kg_second = kg_second.get_pairs(second_edge_type, type="head_tail")
+        second_edge_type_pairs_in_kg_second = kg_second.get_pairs(second_edge_type, type = "head_tail")
         
         # Get indices of the (head, tail) pairs, in kg_train, that are related by first_edge_type
         indices_to_remove_kg_train_reverse = [edge_index
@@ -410,7 +457,7 @@ def clean_datasets( kg_train: KnowledgeGraph,
                                                     if (head.item(), tail.item()) in second_edge_type_pairs_in_kg_second
                                                     and kg_train.edge_indices[edge_index].item() == first_edge_type])
 
-        # Remove those (head, tail) pairs from kg_train
+        # Remove these (head, tail) pairs from kg_train
         kg_train = kg_train.remove_triplets(torch.tensor(indices_to_remove_kg_train_reverse, dtype=torch.long))
 
         logging.info(f"Found {len(indices_to_remove_kg_train_reverse)} reverse triplets to remove for edge {first_edge_type} with reverse {second_edge_type}.")
@@ -428,28 +475,27 @@ def clean_cartesians(kg_first: KnowledgeGraph,
     For each node (head or tail) involved in a cartesian product edge in the test set,
     all corresponding triplets in the training set are moved to the test set.
     
-    Parameters
-    ----------
+    Arguments
+    ---------
     kg_first: KnowledgeGraph
         Train set knowledge graph to be cleaned.
         Will be modified by removing cartesian product triplets.
     kg_second: KnowledgeGraph
         Test set knowledge graph to be augmented.
         Will receive the transferred cartesian product triplets.
-    known_cartesian: list
+    known_cartesian: List[int]
         List of edge indices that represent cartesian product relationships.
         These are edges where if (head, tail 1, edge) exists, then (head, tail 2, edge) likely exists
         for many other tail nodes 'tail 2' (or vice versa for tail-based cartesian products).
-    node_type: str, optional
+    node_type: str, optional, default to "head"
         Either "head" or "tail" to specify which node type to consider for cartesian products.
-        Default is "head".
     
     Returns
     -------
-    tuple (KnowledgeGraph, KnowledgeGraph)
-        A pair of (cleaned_train_kg, augmented_test_kg) where:
-        - cleaned_train_kg: Training KG with cartesian triplets removed
-        - augmented_test_kg: Test KG with the transferred triplets added
+    kg_first: KnowledgeGraph
+        Cleaned train knowledge graph, with cartesian triplets removed
+    kg_second: KnowledgeGraph
+        Augmented test knowledge graph, with the transferred triplets added
         
     """
     assert node_type in ["head", "tail"], "node_type must be either 'head' or 'tail'"

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -20,9 +20,9 @@ SUPPORTED_SEPARATORS = [",","\t",";"]
 
 
 def prepare_knowledge_graph(config: dict, 
-                            kg: KnowledgeGraph | None, 
-                            dataframe: pd.DataFrame | None,
-                            metadata: pd.DataFrame | None
+                            kg: KnowledgeGraph | None = None, 
+                            dataframe: pd.DataFrame | None = None,
+                            metadata: pd.DataFrame | None = None
                             ) -> Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph]:
     """
     Prepare and clean the knowledge graph.
@@ -35,12 +35,12 @@ def prepare_knowledge_graph(config: dict,
     ---------
     config: dict
         The full configuration, usually parsed from the KGATE configuration file.
-    kg: KnowledgeGraph
+    kg: KnowledgeGraph, optional
         The knowledge graph as a single object of class KnowledgeGraph or inheriting the class (KnowledgeGraph inherits the class)
-    dataframe: pd.DataFrame
+    dataframe: pd.DataFrame, optional
         The knowledge graph as a pandas DataFrame.
-    metadata: pd.DataFrame
-        TODO: description here
+    metadata: pd.DataFrame, optional
+        The metadata dataframe to associate to the knowledge graph.
 
     Raises
     ------

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -30,10 +30,6 @@ def prepare_knowledge_graph(config: dict,
     This function takes an input knowledge graph either as a csv file (from the configuration), an object of type
     `torchkge.KnowledgeGraph` or a pandas `DataFrame`. It is preprocessed by the `clean_knowledge_graph` function
     and saved as a pickle file with the `save_knowledge_graph` function.
-    
-    Notes
-    -----
-    The CSV file can have any number of columns but at least three named head, tail and edge.
 
     Arguments
     ---------
@@ -49,11 +45,11 @@ def prepare_knowledge_graph(config: dict,
     Raises
     ------
     ValueError
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-    ValueError
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        Knowledge graph csv file not found or using a non supported separator.
+        Supported separators are "," (comma), "\t" (tabulation), ";" (semicolon).
     NotImplementedError
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        Knowledge graph type not supported.
+        Supported knowledge graph types are KGATE's and TorchKGE's.
         
     Returns
     -------
@@ -63,7 +59,11 @@ def prepare_knowledge_graph(config: dict,
         Subpart of the preprocessed and split knowledge graph, for validation.
     kg_test: KnowledgeGraph
         Subpart of the preprocessed and split knowledge graph, for test.
-        
+    
+    Notes
+    -----
+    The CSV file can have any number of columns but at least three named head, tail and edge.
+    
     """
     # Load knowledge graph
     if kg is None and dataframe is None:
@@ -80,7 +80,7 @@ def prepare_knowledge_graph(config: dict,
                 continue
         
         if kg_dataframe is None:
-            raise ValueError(f"The Knowledge Graph csv file was not found or uses a non supported separator. Supported separators are '{'\', \''.join(SUPPORTED_SEPARATORS)}'.")
+            raise ValueError(f"The knowledge graph csv file was not found or uses a non supported separator. Supported separators are '{'\', \''.join(SUPPORTED_SEPARATORS)}'.")
 
         kg = KnowledgeGraph(dataframe = kg_dataframe, metadata = metadata)
 
@@ -92,7 +92,7 @@ def prepare_knowledge_graph(config: dict,
             elif isinstance(kg, KnowledgeGraph):
                 kg = kg
             else:
-                raise NotImplementedError(f"Knowledge Graph type {type(kg)} is not supported.")
+                raise NotImplementedError(f"Knowledge graph type {type(kg)} is not supported. Supported knowledge graph types are KGATE's and TorchKGE's.")
         elif dataframe is not None:
             kg = KnowledgeGraph(dataframe = dataframe, metadata = metadata)
                 
@@ -145,7 +145,7 @@ def load_knowledge_graph(pickle_filename: Path):
     Arguments
     ---------
     pickle_filename: Path
-        TODO.What_that_argument_is_or_does
+        Path to the pickle file.
         
     Returns
     -------
@@ -170,14 +170,14 @@ def clean_knowledge_graph(  kg: KnowledgeGraph,
     Arguments
     ---------
     kg: KnowledgeGraph
-        TODO.What_that_argument_is_or_does
+        Knowledge graph on which the cleaning will be done.
     config: dict
-        TODO.What_that_argument_is_or_does
+        The full configuration, usually parsed from the KGATE configuration file.
     
     Raises
     ------
     ValueError
-        TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        One or more nodes are not covered in the training set after ensuring node coverage.
         
     Returns
     -------
@@ -274,13 +274,13 @@ def verify_node_coverage(kg_train: KnowledgeGraph,
     Arguments
     ---------
     kg_train: KnowledgeGraph
-        The training knowledge graph.
+        The training knowledge graph subset.
     kg_full: KnowledgeGraph
         The full knowledge graph.
 
     Returns
     -------
-    TODO.result_name: Tuple[bool, List[str]]
+    missing_nodes: Tuple[bool, List[str]]
         A tuple where the first element is True if all nodes in the full knowledge graph are present in the training 
         knowledge graph, and the second element is a list of missing nodes (names) if any are missing.
     
@@ -306,20 +306,20 @@ def verify_node_coverage(kg_train: KnowledgeGraph,
 
 def ensure_node_coverage(kg_train: KnowledgeGraph,
                         kg_validation: KnowledgeGraph,
-                        kg_test:KnowledgeGraph
+                        kg_test: KnowledgeGraph
                         ) -> Tuple[KnowledgeGraph, KnowledgeGraph, KnowledgeGraph]:
     """
     Ensure that all nodes in kg_train.node_to_index are present in kg_train as head or tail.
-    If an node is missing, move a triplet involving that node from kg_validation or kg_test to kg_train.
+    If a node is missing, move a triplet involving that node from kg_validation or kg_test to kg_train.
 
     Arguments
     ---------
     kg_train: KnowledgeGraph
-        The training knowledge graph to ensure node coverage.
+        The training knowledge graph subset to ensure node coverage of.
     kg_validation: KnowledgeGraph
-        The validation knowledge graph from which to move triplets if needed.
+        The validation knowledge graph subset from which to move triplets if needed.
     kg_test: KnowledgeGraph
-        The test knowledge graph from which to move triplets if needed.
+        The test knowledge graph subset from which to move triplets if needed.
 
     Returns
     -------
@@ -378,6 +378,7 @@ def ensure_node_coverage(kg_train: KnowledgeGraph,
             # Update the list of missing nodes
             nodes_in_triplets = set(triplets[0].tolist() + triplets[1].tolist())
             remaining_nodes = nodes - set(nodes_in_triplets)
+            
             return remaining_nodes
         
         return nodes
@@ -406,16 +407,16 @@ def clean_datasets( kg_train: KnowledgeGraph,
     Arguments
     ---------
     kg_train: KnowledgeGraph
-        The training knowledge graph.
+        The training knowledge graph subset.
     kg_second: KnowledgeGraph
-        The second knowledge graph, test or validation.
+        The second knowledge graph subset, test or validation.
     known_reverses: List[Tuple[int, int]]
         Each tuple contains two edges (first_edge_type, second_edge_type) that are known reverse edges.
 
     Returns
     -------
     kg_train: KnowledgeGraph
-        The cleaned train knowledge graph.
+        The cleaned train knowledge graph subset.
         
     """
     for first_edge_type, second_edge_type in known_reverses:
@@ -493,9 +494,9 @@ def clean_cartesians(kg_first: KnowledgeGraph,
     Returns
     -------
     kg_first: KnowledgeGraph
-        Cleaned train knowledge graph, with cartesian triplets removed
+        Cleaned train vset knowledge graph, with cartesian triplets removed.
     kg_second: KnowledgeGraph
-        Augmented test knowledge graph, with the transferred triplets added
+        Augmented test set knowledge graph, with the transferred triplets added.
         
     """
     assert node_type in ["head", "tail"], "node_type must be either 'head' or 'tail'"
@@ -505,7 +506,7 @@ def clean_cartesians(kg_first: KnowledgeGraph,
         mask = (kg_second.edge_indices == edge_index)
         if node_type == "head":
             cartesian_node_indices = kg_second.head_indices[mask].view(-1,1)
-            # Find matching triplets in training set with same head and edge
+            # Find matching triplets in train set with same head and edge
             all_indices_to_move = []
             for node_index in cartesian_node_indices:
                 mask = (kg_first.head_indices == node_index) & (kg_first.edge_indices == edge_index)
@@ -515,7 +516,7 @@ def clean_cartesians(kg_first: KnowledgeGraph,
                 all_indices_to_move.extend(indices.tolist())
         else:  # tail
             cartesian_node_indices = kg_second.tail_indices[mask].view(-1,1)
-            # Find matching triplets in training set with same tail and edge
+            # Find matching triplets in train set with same tail and edge
             all_indices_to_move = []
             for node_index in cartesian_node_indices:
                 mask = (kg_first.tail_indices == node_index) & (kg_first.edge_indices == edge_index)
@@ -532,7 +533,7 @@ def clean_cartesians(kg_first: KnowledgeGraph,
                 kg_first.tail_indices[all_indices_to_move]
             ], dim = 1)
             
-            # Remove identified triplets from training set
+            # Remove identified triplets from train set
             kg_first = kg_first.remove_triplets(torch.tensor(all_indices_to_move, dtype = torch.long))
             
             # Add transferred triplets to test set while preserving KG structure

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -93,7 +93,7 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
 
         Arguments
         ---------
-        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+        batch: torch.Tensor, dtype: torch.long, shape: [4, batch_size]
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -107,7 +107,7 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
 
         Returns
         -------
-        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: [4, batch_size]
             Tensor containing the integer key of negatively sampled triplets of
             the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -277,7 +277,7 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
 
         Arguments
         ---------
-        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+        batch: torch.Tensor, dtype: torch.long, shape: [4, batch_size]
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -287,7 +287,7 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
 
         Returns
         -------
-        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, negative_triplet_count * batch_size)
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: [4, negative_triplet_count * batch_size]
             Tensor containing the integer key of negatively sampled triplets of
             the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -410,7 +410,7 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
 
         Arguments
         ---------
-        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+        batch: torch.Tensor, dtype: torch.long, shape: [4, batch_size]
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -420,7 +420,7 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
 
         Returns
         -------
-        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, negative_triplet_count * batch_size)
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: [4, negative_triplet_count * batch_size]
             Tensor containing the integer key of negatively sampled triplets of
             the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -538,7 +538,7 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
 
         Arguments
         ---------
-        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+        batch: torch.Tensor, dtype: torch.long, shape: [4, batch_size]
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
@@ -548,7 +548,7 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
 
         Returns
         -------
-        combined_negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, 2 * negative_triplet_count * batch_size + batch_size)
+        combined_negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: [4, 2 * negative_triplet_count * batch_size + batch_size]
             Tensor containing the integer key of negatively sampled heads and tails from both samplers.
             Here, batch_size is batch.shape[1].
             

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -31,7 +31,7 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
     triplet (involving the same edge), using bernoulli sampling.
 
     If the corrupted triplet is of a type that doesn't exist in the original knowledge graph,
-    it is createad.
+    it is created.
 
     Arguments
     ---------
@@ -40,30 +40,43 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
             
     Attributes
     ----------
-    possible_heads: Dict[int, List[int]]
+    possible_heads: Dict[int, torch.Tensor]
         keys: edges
-        values: list of possible heads for each edge.
-    possible_tails: Dict[int, List[int]]
+        values: list of number of possible heads for each edge, equivalent to possible_head_count
+    possible_tails: Dict[int, torch.Tensor]
         keys: edges
-        values: list of possible tails for each edge.
-    possible_head_count: List[int]
+        values: list of number of possible tails for each edge, equivalent to possible_tail_count
+    possible_head_count: torch.Tensor
         List of number of possible heads for each edge.
-    possible_tail_count: List[int]
+        Equivalent of List[int], but with Tensor possibilities.
+    possible_tail_count: torch.Tensor
         List of number of possible tails for each edge.
+        Equivalent of List[int], but with Tensor possibilities.
     index_to_node_type: Dict[int, str]
         keys: node index
         values: node types
     edge_types: Dict[int, str]
         keys: edge index
         values: edge name
+    kg: KnowledgeGraph
+        Knowledge graph on which the sampling will be done.
+    node_count: int
+        Number of nodes.
+    bernoulli_probabilities: torch.Tensor
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
     
     Notes
     -----
     Also fixes GPU/CPU incompatibility bug.
     See original implementation here: https://github.com/torchkge-team/torchkge/blob/3adb9344dec974fc29d158025c014b0dcb48118c/torchkge/sampling.py#L330C52-L330C53
     
+    Slower than UniformNegativeSampler, BernoulliNegativeSampler and MixedNegativeSampler, as it searches
+    in the entire knowledge graph instead of a batch.
+    
     """
     def __init__(self, kg: KnowledgeGraph):
+        
         super().__init__(kg)
         self.index_to_node_type = {value: key for key, value in self.kg.node_type_to_index.items()}
         self.edge_types = {value: key for key,value in self.kg.edge_to_index.items()}
@@ -75,7 +88,7 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
                         ) -> Tensor:
         """
         For each true triplet, produce a corrupted one not different from
-        any other golden triplet. If `heads` and `tails` are cuda objects,
+        any other true triplet. If `heads` and `tails` are cuda objects,
         then the returned tensors are on the GPU.
 
         Arguments
@@ -83,19 +96,21 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
         batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
+            Here, batch_size is batch.shape[1].
 
         Raises
         ------
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        AssertionError #1
+            The size/shape of possible_head_count must be corrupted_head_count.
+        AssertionError #2
+            The size/shape of possible_head_count must be (batch_size - corrupted_head_count).
 
         Returns
         -------
-        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (batch_size)
-            Tensor containing the integer key of negatively sampled nodes of
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+            Tensor containing the integer key of negatively sampled triplets of
             the edges in the current batch.
+            Here, batch_size is batch.shape[1].
             
         """
         edges = batch[2]
@@ -103,12 +118,12 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
         node_types = self.kg.node_types
         triplet_types = self.kg.triple_types
 
-        batch_size = batch.size(1)
+        batch_size = batch.shape[1]
         negative_triplets_batch: Tensor = batch.clone().long()
 
-        self.bernoulli_probabilitiess = self.bernoulli_probabilitiess.to(device)
+        self.bernoulli_probabilities = self.bernoulli_probabilities.to(device)
         # Randomly choose which samples will have head/tail corrupted
-        mask = bernoulli(self.bernoulli_probabilitiess[edges]).double()
+        mask = bernoulli(self.bernoulli_probabilities[edges]).double()
         corrupted_head_count = int(mask.sum().item())
 
         self.possible_head_count = self.possible_head_count.to(device)
@@ -204,6 +219,12 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
 class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
     """
     TODO.What_the_class_is_about_globally
+    For each edge, choose simultenously head and tail from Bernoulli random distribution.
+    
+    Check that no true triplet is created by accident.
+
+    If the corrupted triplet is of a type that doesn't exist in the original knowledge graph,
+    it is created.
 
     References
     ----------
@@ -212,7 +233,7 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
     Arguments
     ---------
     kg: KnowledgeGraph
-        TODO.What_that_argument_is_or_does
+        Knowledge graph on which the sampling will be done.
     negative_triplet_count: int, optional, default to 1
         Number of negative samples to create from each triplet. If None, the class-level
         `n_neg` value is used.
@@ -224,8 +245,15 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
     edge_types: Dict[int, str]
         keys: edge index
         values: edge name
-    n_neg: TODO.type
-        TODO.What_that_variable_is_or_does
+    kg: KnowledgeGraph
+        Knowledge graph on which the sampling will be done.
+    n_neg: int
+        Number of negative samples to create from each triplet.
+        Inherited attribute, equivalent to negative_triplet_count.
+    n_ent: int
+        Number of nodes.
+        Inherited attribute equivalent to node_count.
+    
     TODO.inherited_attributes
     
     """
@@ -243,26 +271,32 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
                         negative_triplet_count = None
                         ) -> Tensor:
         """
-        TODO.What_the_function_does_about_globally
+        For each true triplet, produce a corrupted one not different from
+        any other true triplet. If `heads` and `tails` are cuda objects,
+        then the returned tensors are on the GPU.
 
         Arguments
         ---------
-        batch: torch.Tensor
-            TODO.What_that_argument_is_or_does
+        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+            Tensor containing the integer key of heads, tails, edges and triplets
+            of the edges in the current batch.
+            Here, batch_size is batch.shape[1].
         negative_triplet_count: int, optional, default to None
             Number of negative samples to create from each triplet. If None, the class-level
             `n_neg` value is used.
 
         Returns
         -------
-        result_name: TODO.type
-            TODO.What_that_variable_is_or_does
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, negative_triplet_count * batch_size)
+            Tensor containing the integer key of negatively sampled triplets of
+            the edges in the current batch.
+            Here, batch_size is batch.shape[1].
             
         """
         negative_triplet_count = negative_triplet_count or self.n_neg
 
         device = batch.device
-        batch_size = batch.size(1)
+        batch_size = batch.shape[1]
         negative_triplet_heads = batch[0].repeat(negative_triplet_count)
         negative_triplet_tails = batch[1].repeat(negative_triplet_count)
         negative_triplet_edges = batch[2].repeat(negative_triplet_count)
@@ -284,7 +318,7 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
                                 negative_triplet_tails,
                                 negative_triplet_edges,
                                 batch[3].repeat(negative_triplet_count)],
-                                dim=0).long().to(device)
+                                dim = 0).long().to(device)
         
         corrupted_triplets = []
         node_types = self.kg.node_types
@@ -318,6 +352,12 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
 class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
     """
     TODO.What_the_class_is_about_globally
+    For each edge, choose head from Bernoulli random distribution, then tail from Bernoulli random distribution.
+    
+    Check that no true triplet is created by accident.
+
+    If the corrupted triplet is of a type that doesn't exist in the original knowledge graph,
+    it is created.
 
     References
     ----------
@@ -326,7 +366,7 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
     Arguments
     ---------
     kg: KnowledgeGraph
-        TODO.What_that_argument_is_or_does
+        Knowledge graph on which the sampling will be done.
     negative_triplet_count: int, optional, default to 1
         Number of negative samples to create from each triplet. If None, the class-level
         `n_neg` value is used.
@@ -338,9 +378,15 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
     edge_types: Dict[int, str]
         keys: edge index
         values: edge name
-    n_neg: TODO.type
-        TODO.What_that_variable_is_or_does
-    bernoulli_probabilities: TODO.type
+    kg: KnowledgeGraph
+        Knowledge graph on which the sampling will be done.
+    n_neg: int
+        Number of negative samples to create from each triplet.
+        Inherited attribute, equivalent to negative_triplet_count.
+    n_ent: int
+        Number of nodes.
+        Inherited attribute equivalent to node_count.
+    bernoulli_probabilities: torch.Tensor
         TODO.What_that_variable_is_or_does
     TODO.inherited_attributes
     
@@ -358,26 +404,32 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
                         batch: torch.LongTensor,
                         negative_triplet_count = None):
         """
-        TODO.What_the_function_does_about_globally
+        For each true triplet, produce a corrupted one not different from
+        any other true triplet. If `heads` and `tails` are cuda objects,
+        then the returned tensors are on the GPU.
 
         Arguments
         ---------
-        batch: torch.LongTensor
-            TODO.What_that_argument_is_or_does
-        negative_triplet_count: int, optional, default to None
+        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+            Tensor containing the integer key of heads, tails, edges and triplets
+            of the edges in the current batch.
+            Here, batch_size is batch.shape[1].
+        negative_triplet_count: int, optional
             Number of negative samples to create from each triplet. If None, the class-level
             `n_neg` value is used.
 
         Returns
         -------
-        result_name: TODO.type
-            TODO.What_that_variable_is_or_does
+        negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, negative_triplet_count * batch_size)
+            Tensor containing the integer key of negatively sampled triplets of
+            the edges in the current batch.
+            Here, batch_size is batch.shape[1].
             
         """
         negative_triplet_count = negative_triplet_count or self.n_neg
 
         device = batch.device
-        batch_size = batch.size(1)
+        batch_size = batch.shape[1]
         negative_triplet_heads = batch[0].repeat(negative_triplet_count)
         negative_triplet_tails = batch[1].repeat(negative_triplet_count)
         negative_triplet_edges = batch[2]
@@ -402,12 +454,13 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
                                 negative_triplet_tails,
                                 negative_triplet_edges.repeat(negative_triplet_count),
                                 batch[3].repeat(negative_triplet_count)],
-                                dim=0
+                                dim = 0
                                 ).long().to(device)
         
         corrupted_triplets = []
         node_types = self.kg.node_types
         triplet_types = self.kg.triple_types
+        
         for i in range(batch_size):
             head = negative_triplet_heads[i]
             tail = negative_triplet_tails[i]
@@ -436,7 +489,7 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
 
 class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     """
-    A custom negative sampler that combines the BernoulliNegativeSampler
+    A custom negative sampler that combines the BernoulliNegativeSampler, the UniformNegativeSampler
     and the PositionalNegativeSampler. For each triplet, it samples `n_neg` negative samples
     using both samplers.
     
@@ -445,11 +498,15 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     kg: KnowledgeGraph
         Main knowledge graph (usually training one).
     negative_triplet_count: int, optional, default to 1
-        Number of negative samples to create from each triplet. If None, the class-level
-        `n_neg` value is used.
+        Third of the number of negative samples to create from each triplet. Since it uses 3 sampler
+        methods, it generates 3 times the amount of negative_triplet_count indicated.
+        If None, the class-level `n_neg` value is used.
 
     Attributes
     ----------
+    n_neg: int
+        Number of negative samples to create from each triplet.
+        Inherited attribute, equivalent to negative_triplet_count.
     uniform_sampler: TODO.type
         TODO.What_that_variable_is_or_does
     bernoulli_sampler: TODO.type
@@ -465,7 +522,7 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
                 negative_triplet_count = 1):
         
         super().__init__(kg, n_neg = negative_triplet_count)
-        # Initialize both Bernoulli and Positional samplers
+        # Initialize both Bernoulli, Uniform and Positional samplers
         self.uniform_sampler = UniformNegativeSampler(kg, negative_triplet_count = negative_triplet_count)
         self.bernoulli_sampler = BernoulliNegativeSampler(kg, negative_triplet_count = negative_triplet_count)
         self.positional_sampler = PositionalNegativeSampler(kg)
@@ -474,23 +531,26 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     def corrupt_batch(  self,
                         batch: torch.LongTensor,
                         negative_triplet_count = None):
-        """ TODO
+        """
         For each true triplet, produce `negative_triplet_count` corrupted ones from the
-        Unniform sampler, the Bernoulli sampler and the Positional sampler. If `heads` and `tails` are
+        Uniform sampler, the Bernoulli sampler and the Positional sampler. If `heads` and `tails` are
         cuda objects, then the returned tensors are on the GPU.
 
         Arguments
         ---------
-        batch: torch.LongTensor
-            TODO.What_that_argument_is_or_does
+        batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
+            Tensor containing the integer key of heads, tails, edges and triplets
+            of the edges in the current batch.
+            Here, batch_size is batch.shape[1].
         negative_triplet_count: int, optional, default to None
             Number of negative samples to create from each triplet. If None, the class-level
             `n_neg` value is used.
 
         Returns
         -------
-        combined_negative_triplets_batch: torch.Tensor, dtype: torch.long
+        combined_negative_triplets_batch: torch.Tensor, dtype: torch.long, shape: (4, 2 * negative_triplet_count * batch_size + batch_size)
             Tensor containing the integer key of negatively sampled heads and tails from both samplers.
+            Here, batch_size is batch.shape[1].
             
         """
         negative_triplet_count = negative_triplet_count or self.n_neg

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -30,11 +30,11 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
     chosen among nodes that have already appeared at the same place in a
     triplet (involving the same edge), using bernoulli sampling.
 
-    If the corrupted triplet is of a type that doesn't exist in the original KG,
+    If the corrupted triplet is of a type that doesn't exist in the original knowledge graph,
     it is createad.
 
-    Parameters
-    ----------
+    Arguments
+    ---------
     kg: kgate.data_structure.KnowledgeGraph
         Knowledge Graph from which the corrupted triplets will be created.
             
@@ -70,18 +70,26 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
 
 
     def corrupt_batch(  self,
-                        batch: Tensor, _: int = 0
+                        batch: Tensor,
+                        _: int = 0
                         ) -> Tensor:
         """
         For each true triplet, produce a corrupted one not different from
         any other golden triplet. If `heads` and `tails` are cuda objects,
         then the returned tensors are on the GPU.
 
-        Parameters
-        ----------
+        Arguments
+        ---------
         batch: torch.Tensor, dtype: torch.long, shape: (4, batch_size)
             Tensor containing the integer key of heads, tails, edges and triplets
             of the edges in the current batch.
+
+        Raises
+        ------
+        error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+        error_name
+            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
 
         Returns
         -------
@@ -124,8 +132,8 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
             edge_index = corrupted_head_batch[2][i].item()
             choices: Dict[Number, Set[Number]] = self.possible_heads[edge_index]
             if len(choices) == 0:
-                # in this case the edge i has never been used with any head
-                # choose one node at random
+                # In this case the edge i has never been used with any head
+                # Choose one node at random
                 corrupted_head_index = randint(low = 0, high = self.node_count, size = (1,)).item()
             else:
                 corrupted_head_index = choices[chosen_head[i].item()]
@@ -162,8 +170,8 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
             edge_index = corrupted_tail_batch[2][i].item()
             choices: Dict[Number, Set[Number]] = self.possible_tails[edge_index]
             if len(choices) == 0:
-                # in this case the edge i has never been used with any tail
-                # choose one node at random
+                # In this case the edge i has never been used with any tail
+                # Choose one node at random
                 corrupted_tail_index = randint(low = 0, high = self.node_count, size = (1,)).item()
             else:
                 corrupted_tail_index = choices[chosen_tail[i].item()]
@@ -192,8 +200,35 @@ class PositionalNegativeSampler(torchkge.sampling.PositionalNegativeSampler):
         return negative_triplets_batch
 
 
+
 class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    kg: KnowledgeGraph
+        TODO.What_that_argument_is_or_does
+    negative_triplet_count: int, optional, default to 1
+        Number of negative samples to create from each triplet. If None, the class-level
+        `n_neg` value is used.
+
+    Attributes
+    ----------
+    index_to_node_type: Dict[int, str]
+        keys: node index
+    edge_types: Dict[int, str]
+        keys: edge index
+        values: edge name
+    n_neg: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
     
+    """
     def __init__(self,
                 kg: KnowledgeGraph,
                 negative_triplet_count = 1):
@@ -205,9 +240,25 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
     
     def corrupt_batch(  self,
                         batch: torch.Tensor,
-                        negative_triplet_count=None
+                        negative_triplet_count = None
                         ) -> Tensor:
-        
+        """
+        TODO.What_the_function_does_about_globally
+
+        Arguments
+        ---------
+        batch: torch.Tensor
+            TODO.What_that_argument_is_or_does
+        negative_triplet_count: int, optional, default to None
+            Number of negative samples to create from each triplet. If None, the class-level
+            `n_neg` value is used.
+
+        Returns
+        -------
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         negative_triplet_count = negative_triplet_count or self.n_neg
 
         device = batch.device
@@ -260,14 +311,43 @@ class UniformNegativeSampler(torchkge.sampling.UniformNegativeSampler):
                 triplet
             ]))
 
-        return torch.stack(corrupted_triplets, dim=1).long().to(device)
-    
-    
+        return torch.stack(corrupted_triplets, dim = 1).long().to(device)
+
+
+
 class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
+    """
+    TODO.What_the_class_is_about_globally
+
+    References
+    ----------
+    TODO
+
+    Arguments
+    ---------
+    kg: KnowledgeGraph
+        TODO.What_that_argument_is_or_does
+    negative_triplet_count: int, optional, default to 1
+        Number of negative samples to create from each triplet. If None, the class-level
+        `n_neg` value is used.
+
+    Attributes
+    ----------
+    index_to_node_type: Dict[int, str]
+        keys: node index
+    edge_types: Dict[int, str]
+        keys: edge index
+        values: edge name
+    n_neg: TODO.type
+        TODO.What_that_variable_is_or_does
+    bernoulli_probabilities: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
     
+    """
     def __init__(self,
                 kg,
-                negative_triplet_count=1):
+                negative_triplet_count = 1):
         
         super().__init__(kg, n_neg = negative_triplet_count)
         self.index_to_node_type = {value: key for key,value in self.kg.node_type_to_index.items()}
@@ -276,8 +356,24 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
 
     def corrupt_batch(  self,
                         batch: torch.LongTensor,
-                        negative_triplet_count=None):
-        
+                        negative_triplet_count = None):
+        """
+        TODO.What_the_function_does_about_globally
+
+        Arguments
+        ---------
+        batch: torch.LongTensor
+            TODO.What_that_argument_is_or_does
+        negative_triplet_count: int, optional, default to None
+            Number of negative samples to create from each triplet. If None, the class-level
+            `n_neg` value is used.
+
+        Returns
+        -------
+        result_name: TODO.type
+            TODO.What_that_variable_is_or_does
+            
+        """
         negative_triplet_count = negative_triplet_count or self.n_neg
 
         device = batch.device
@@ -335,26 +431,39 @@ class BernoulliNegativeSampler(torchkge.sampling.BernoulliNegativeSampler):
             ]))
 
         return torch.stack(corrupted_triplets, dim = 1).long().to(device)
-        
-        
+
+
+
 class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     """
     A custom negative sampler that combines the BernoulliNegativeSampler
     and the PositionalNegativeSampler. For each triplet, it samples `n_neg` negative samples
     using both samplers.
     
-    Parameters
-    ----------
-    kg: torchkge.data_structures.KnowledgeGraph
+    Arguments
+    ---------
+    kg: KnowledgeGraph
         Main knowledge graph (usually training one).
-    negative_triplet_count: int
-        Number of negative samples to create from each fact.
+    negative_triplet_count: int, optional, default to 1
+        Number of negative samples to create from each triplet. If None, the class-level
+        `n_neg` value is used.
+
+    Attributes
+    ----------
+    uniform_sampler: TODO.type
+        TODO.What_that_variable_is_or_does
+    bernoulli_sampler: TODO.type
+        TODO.What_that_variable_is_or_does
+    positional_sampler: TODO.type
+        TODO.What_that_variable_is_or_does
+    TODO.inherited_attributes
         
     """
     
     def __init__(self,
                 kg,
                 negative_triplet_count = 1):
+        
         super().__init__(kg, n_neg = negative_triplet_count)
         # Initialize both Bernoulli and Positional samplers
         self.uniform_sampler = UniformNegativeSampler(kg, negative_triplet_count = negative_triplet_count)
@@ -365,21 +474,23 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     def corrupt_batch(  self,
                         batch: torch.LongTensor,
                         negative_triplet_count = None):
-        """
+        """ TODO
         For each true triplet, produce `negative_triplet_count` corrupted ones from the
         Unniform sampler, the Bernoulli sampler and the Positional sampler. If `heads` and `tails` are
         cuda objects, then the returned tensors are on the GPU.
 
-        Parameters
-        ----------
-        negative_triplet_count: int (optional)
-            Number of negative samples to create from each fact. If None, the class-level
+        Arguments
+        ---------
+        batch: torch.LongTensor
+            TODO.What_that_argument_is_or_does
+        negative_triplet_count: int, optional, default to None
+            Number of negative samples to create from each triplet. If None, the class-level
             `n_neg` value is used.
 
         Returns
         -------
         combined_negative_triplets_batch: torch.Tensor, dtype: torch.long
-            Tensor containing the integer key of negatively sampled heads and tailsfrom both samplers.
+            Tensor containing the integer key of negatively sampled heads and tails from both samplers.
             
         """
         negative_triplet_count = negative_triplet_count or self.n_neg
@@ -404,6 +515,6 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
                                                 uniform_negative_triplets_batch,
                                                 bernoulli_negative_triplets_batch,
                                                 positional_negative_triplets_batch
-                                                ], dim=1)
+                                                ], dim = 1)
         
         return combined_negative_triplets_batch

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -507,12 +507,12 @@ class MixedNegativeSampler(torchkge.sampling.NegativeSampler):
     n_neg: int
         Number of negative samples to create from each triplet.
         Inherited attribute, equivalent to negative_triplet_count.
-    uniform_sampler: TODO.type
-        TODO.What_that_variable_is_or_does
-    bernoulli_sampler: TODO.type
-        TODO.What_that_variable_is_or_does
-    positional_sampler: TODO.type
-        TODO.What_that_variable_is_or_does
+    uniform_sampler: UniformNegativeSampler
+        TODO.brief_description_of_the_class
+    bernoulli_sampler: BernoulliNegativeSampler
+        TODO.brief_description_of_the_class
+    positional_sampler: PositionalNegativeSampler
+        TODO.brief_description_of_the_class
     TODO.inherited_attributes
         
     """

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -20,6 +20,13 @@ from torch.types import Number, Tensor
 from .knowledgegraph import KnowledgeGraph
 from .utils import get_bernoulli_probabilities
 
+class NegativeSampler:
+    """This class is a simple interface to ease typing and use of negative samplers."""
+    def corrupt_batch(  self,
+                        batch: torch.Tensor,
+                        negative_triplet_count = None
+                        ) -> Tensor:
+        raise NotImplementedError()
 
 class UniformNegativeSampler:
     """

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -21,13 +21,26 @@ from torch.types import Number, Tensor
 from .knowledgegraph import KnowledgeGraph
 from .utils import get_bernoulli_probabilities
 
+
+
 class NegativeSampler:
-    """This class is a simple interface to ease typing and use of negative samplers."""
+    """
+    This class is a simple interface to ease typing and use of negative samplers.
+    TODO
+    
+    """
+    
     def corrupt_batch(  self,
                         batch: torch.Tensor,
                         negative_triplet_count = None
                         ) -> Tensor:
+        """
+        TODO
+    
+        """
         raise NotImplementedError()
+
+
 
 class UniformNegativeSampler:
     """
@@ -48,8 +61,7 @@ class UniformNegativeSampler:
     kg: KnowledgeGraph
         Knowledge graph on which the sampling will be done.
     negative_triplet_count: int, optional, default to 1
-        Number of negative samples to create from each triplet. If None, the class-level
-        `n_neg` value is used.
+        Number of negative samples to create from each triplet.
 
     Attributes
     ----------
@@ -60,12 +72,10 @@ class UniformNegativeSampler:
         values: edge name
     kg: KnowledgeGraph
         Knowledge graph on which the sampling will be done.
-    n_neg: int
+    negative_triplet_count: int
         Number of negative samples to create from each triplet.
-        Inherited attribute, equivalent to negative_triplet_count.
-    n_ent: int
+    node_count: int
         Number of nodes.
-        Inherited attribute equivalent to node_count.
     
     TODO.inherited_attributes
     
@@ -75,8 +85,8 @@ class UniformNegativeSampler:
                 negative_triplet_count = 1):
         
         self.knowledge_graph = knowledge_graph
-        self.index_to_node_type: Dict[int, str] = {value: key for key,value in self.knowledge_graph.node_type_to_index.items()}
-        self.edge_types: Dict[int, str] = {value: key for key,value in self.knowledge_graph.edge_to_index.items()}
+        self.index_to_node_type: Dict[int, str] = {value: key for key, value in self.knowledge_graph.node_type_to_index.items()}
+        self.edge_types: Dict[int, str] = {value: key for key, value in self.knowledge_graph.edge_to_index.items()}
     
         self.negative_triplet_count = negative_triplet_count
     
@@ -107,8 +117,6 @@ class UniformNegativeSampler:
             Here, batch_size is batch.shape[1].
             
         """
-        negative_triplet_count = negative_triplet_count or self.negative_triplet_count
-
         device = batch.device
         batch_size = batch.shape[1]
         negative_triplet_heads = batch[0].repeat(negative_triplet_count)
@@ -119,10 +127,10 @@ class UniformNegativeSampler:
                                 device = device) / 2).double()
         corrupted_head_count = int(mask.sum().item())
 
-        negative_triplet_heads[mask == 1] = randint(1, self.n_ent,
+        negative_triplet_heads[mask == 1] = randint(1, self.node_count,
                                                     (corrupted_head_count,),
                                                     device = device)
-        negative_triplet_tails[mask == 0] = randint(1, self.n_ent,
+        negative_triplet_tails[mask == 0] = randint(1, self.node_count,
                                                     (batch_size * negative_triplet_count - corrupted_head_count,),
                                                     device = device)
         
@@ -182,8 +190,7 @@ class BernoulliNegativeSampler:
     kg: KnowledgeGraph
         Knowledge graph on which the sampling will be done.
     negative_triplet_count: int, optional, default to 1
-        Number of negative samples to create from each triplet. If None, the class-level
-        `n_neg` value is used.
+        Number of negative samples to create from each triplet.
 
     Attributes
     ----------
@@ -194,12 +201,10 @@ class BernoulliNegativeSampler:
         values: edge name
     kg: KnowledgeGraph
         Knowledge graph on which the sampling will be done.
-    n_neg: int
+    negative_triplet_count: int
         Number of negative samples to create from each triplet.
-        Inherited attribute, equivalent to negative_triplet_count.
-    n_ent: int
+    node_count: int
         Number of nodes.
-        Inherited attribute equivalent to node_count.
     bernoulli_probabilities: torch.Tensor, dtype: torch.float, shape: [edge_count]
         Tensor containing the probabilities of sampling a head for each edge.
     TODO.inherited_attributes
@@ -242,6 +247,7 @@ class BernoulliNegativeSampler:
 
         return torch.tensor(final_probabilities).float()
 
+    
     def corrupt_batch(  self,
                         batch: torch.LongTensor,
                         negative_triplet_count = None):
@@ -257,8 +263,7 @@ class BernoulliNegativeSampler:
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
         negative_triplet_count: int, optional
-            Number of negative samples to create from each triplet. If None, the class-level
-            `n_neg` value is used.
+            Number of negative samples to create from each triplet.
 
         Returns
         -------
@@ -268,8 +273,6 @@ class BernoulliNegativeSampler:
             Here, batch_size is batch.shape[1].
             
         """
-        negative_triplet_count = negative_triplet_count or self.n_neg
-
         device = batch.device
         batch_size = batch.shape[1]
         negative_triplet_heads = batch[0].repeat(negative_triplet_count)
@@ -281,11 +284,11 @@ class BernoulliNegativeSampler:
         corrupted_head_count = int(mask.sum().item())
 
         negative_triplet_heads[mask == 1] = randint(1,
-                                                    self.n_ent,
+                                                    self.node_count,
                                                     (corrupted_head_count,),
                                                     device = device)
         negative_triplet_tails[mask == 0] = randint(1,
-                                                    self.n_ent,
+                                                    self.node_count,
                                                     (batch_size * negative_triplet_count - corrupted_head_count,),
                                                     device = device)
         
@@ -343,7 +346,7 @@ class PositionalNegativeSampler(BernoulliNegativeSampler):
     Arguments
     ---------
     kg: kgate.data_structure.KnowledgeGraph
-        Knowledge Graph from which the corrupted triplets will be created.
+        Knowledge graph from which the corrupted triplets will be created.
 
     Attributes
     ----------
@@ -585,19 +588,18 @@ class MixedNegativeSampler:
     negative_triplet_count: int, optional, default to 1
         Third of the number of negative samples to create from each triplet. Since it uses 3 sampler
         methods, it generates 3 times the amount of negative_triplet_count indicated.
-        If None, the class-level `n_neg` value is used.
 
     Attributes
     ----------
-    n_neg: int
+    negative_triplet_count: int
         Number of negative samples to create from each triplet.
         Inherited attribute, equivalent to negative_triplet_count.
     uniform_sampler: UniformNegativeSampler
-        TODO.brief_description_of_the_class
+        TODO.what_that_variable_is_or_does
     bernoulli_sampler: BernoulliNegativeSampler
-        TODO.brief_description_of_the_class
+        TODO.what_that_variable_is_or_does
     positional_sampler: PositionalNegativeSampler
-        TODO.brief_description_of_the_class
+        TODO.what_that_variable_is_or_does
     TODO.inherited_attributes
     
     Notes
@@ -606,7 +608,6 @@ class MixedNegativeSampler:
     unexpected behaviour if used as is.
     
     """
-    
     def __init__(self,
                 knowledge_graph: KnowledgeGraph,
                 negative_triplet_count = 1):
@@ -638,8 +639,7 @@ class MixedNegativeSampler:
             of the edges in the current batch.
             Here, batch_size is batch.shape[1].
         negative_triplet_count: int, optional, default to None
-            Number of negative samples to create from each triplet. If None, the class-level
-            `n_neg` value is used.
+            Number of negative samples to create from each triplet.
 
         Returns
         -------
@@ -648,8 +648,6 @@ class MixedNegativeSampler:
             Here, batch_size is batch.shape[1].
         
         """
-        negative_triplet_count = negative_triplet_count or self.n_neg
-
         # Get negative samples from Uniform sampler
         uniform_negative_triplets_batch = self.uniform_sampler.corrupt_batch(
             batch, negative_triplet_count = negative_triplet_count

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -315,11 +315,11 @@ def concat_kgs( kg_train: KnowledgeGraph,
 
     Returns
     -------
-    head: torch.Tensor, shape: (merged_kg.node_count)
+    head: torch.Tensor, shape: [merged_kg.node_count]
         List of head indices.
-    tail: torch.Tensor, shape: (merged_kg.node_count)
+    tail: torch.Tensor, shape: [merged_kg.node_count]
         List of tail indices.
-    edge: torch.Tensor, shape: (merged_kg.node_count)
+    edge: torch.Tensor, shape: [merged_kg.node_count]
         List of edge indices.
     
     Notes

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -1,4 +1,6 @@
-"""Utility functions for Knowledge Graph manipulation, data visualisation or file handling."""
+"""
+Utility functions for Knowledge Graph manipulation, data visualisation or file handling.
+"""
 
 import os
 import tomllib
@@ -41,19 +43,22 @@ def parse_config(config_path: str,
         Arguments
         ---------
         config_path: str
-            TODO.What_that_argument_is_or_does
-        config_dictionnary: dict
-            TODO.What_that_argument_is_or_does
+            The complete path to the configuration file. If one already exists, it will be overwritten.
+        config_dictionnary: dict, optional
+            The parsed configuration as a python dictionnary.
 
         Raises
         ------
         FileNotFoundError
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-
+            The configuration file is not found at the indicated path.
+            Check that you gave the correct path, and that it is a str.
+            If you give a relative path, it must be relative to the run script path.
+        
         Returns
         -------
         config: dict
-            TODO.What_that_variable_is_or_does
+            The final parsed configuration as a python dictionnary.
+            Using priority orders: inline configuration, configuration file, default configuration
             
         """
     if config_path != "" and not Path(config_path).exists():
@@ -94,16 +99,16 @@ def set_config_key( key: str,
         Arguments
         ---------
         default: dict
+            The default parsed configuration as a python dictionnary.
+        config: dict, optional
             TODO.What_that_argument_is_or_does
-        config: dict, optional, default to None
-            TODO.What_that_argument_is_or_does
-        inline: dict, optional, default to None
-            TODO.What_that_argument_is_or_does
+        inline: dict, optional
+            The inline parsed configuration as a python dictionnary.
 
         Raises
         ------
         ValueError
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+            A parameter without a default value is required but not set.
 
         Returns
         -------
@@ -184,19 +189,19 @@ def load_knowledge_graph(pickle_filename: Path
     Arguments
     ---------
     pickle_filename: Path
-        TODO.What_that_argument_is_or_does
+        The complete path to the pickle file (.pkl).
 
     Returns
     -------
     kg_train: KnowledgeGraph
-        TODO.What_that_variable_is_or_does
+        Train split from the knowledge graph, directly loaded from the pickle file.
     kg_validation: KnowledgeGraph
-        TODO.What_that_variable_is_or_does
+        Validation split from the knowledge graph, directly loaded from the pickle file.
     kg_test: KnowledgeGraph
-        TODO.What_that_variable_is_or_does
+        Test split from the knowledge graph, directly loaded from the pickle file.
     
     """
-    logging.info(f"Will not run the preparation step. Using KG stored in: {pickle_filename}")
+    logging.info(f"Will not run the preparation step. Using knowledge graph stored in: {pickle_filename}")
     with open(pickle_filename, "rb") as file:
         kg_train = pickle.load(file)
         kg_validation = pickle.load(file)
@@ -232,7 +237,7 @@ def extract_node_type(node_name: str):
 
     Returns
     -------
-    TODO.result_name: TODO.type
+    node_type: str
         TODO.What_that_variable_is_or_does
     
     """
@@ -245,16 +250,16 @@ def compute_triplet_proportions(kg_train: KnowledgeGraph,
                                 ) -> dict:
     """
     Computes the proportion of triplets for each edge in each of the KnowledgeGraphs
-    (train, test, val) relative to the total number of triplets for that edge.
+    (train, test, validation) relative to the total number of triplets for that edge.
 
     Arguments
     ---------
     kg_train: KnowledgeGraph
-        The training KnowledgeGraph instance.
+        Train split from the knowledge graph.
     kg_test: KnowledgeGraph
-        The test KnowledgeGraph instance.
+        Test split from the knowledge graph.
     kg_validation: KnowledgeGraph
-        The validation KnowledgeGraph instance.
+        Validation split from the knowledge graph.
 
     Returns
     -------
@@ -297,25 +302,29 @@ def concat_kgs( kg_train: KnowledgeGraph,
                 kg_test: KnowledgeGraph
                 ) -> Tuple[Tensor, Tensor, Tensor]:
     """
-    TODO.What_the_function_does_about_globally
+    Merge the 3 splits of a knowledge graph into the original knowledge graph.
 
     Arguments
     ---------
     kg_train: KnowledgeGraph
-        The training KnowledgeGraph instance.
+        Train split from the knowledge graph.
     kg_test: KnowledgeGraph
-        The test KnowledgeGraph instance.
+        Test split from the knowledge graph.
     kg_validation: KnowledgeGraph
-        The validation KnowledgeGraph instance.
+        Validation split from the knowledge graph.
 
     Returns
     -------
-    head: torch.Tensor
-        TODO.What_that_variable_is_or_does
-    tail: torch.Tensor
-        TODO.What_that_variable_is_or_does
-    edge: torch.Tensor
-        TODO.What_that_variable_is_or_does
+    head: torch.Tensor, shape: (merged_kg.node_count)
+        List of head indices.
+    tail: torch.Tensor, shape: (merged_kg.node_count)
+        List of tail indices.
+    edge: torch.Tensor, shape: (merged_kg.node_count)
+        List of edge indices.
+    
+    Notes
+    -----
+    (merged_kg.node_count) is the number of nodes of the newly merged knowledge graph.
     
     """
     head = cat((kg_train.head_indices,
@@ -344,9 +353,9 @@ def count_triplets( kg1: KnowledgeGraph,
     Arguments
     ---------
     kg1: KnowledgeGraph
-        TODO.What_that_argument_is_or_does
+        First knowledge graph.
     kg2: KnowledgeGraph
-        TODO.What_that_argument_is_or_does
+        Second knowledge graph.
     duplicates: List[Tuple[int, int]]
         List returned by torchkge.utils.data_redundancy.duplicates.
     reverse_duplicates: List[Tuple[int, int]]

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -34,33 +34,33 @@ def parse_config(config_path: str,
                 config_dictionnary: dict
                 ) -> dict:
     """
-        TODO.What_the_function_does_about_globally
-
-        References
-        ----------
-        TODO
-
-        Arguments
-        ---------
-        config_path: str
-            The complete path to the configuration file. If one already exists, it will be overwritten.
-        config_dictionnary: dict, optional
-            The parsed configuration as a python dictionnary.
-
-        Raises
-        ------
-        FileNotFoundError
-            The configuration file is not found at the indicated path.
-            Check that you gave the correct path, and that it is a str.
-            If you give a relative path, it must be relative to the run script path.
+    TODO.What_the_function_does_about_globally
+    
+    References
+    ----------
+    TODO
+    
+    Arguments
+    ---------
+    config_path: str
+        The complete path to the configuration file. If one already exists, it will be overwritten.
+    config_dictionnary: dict, optional
+        The parsed configuration as a python dictionnary.
         
-        Returns
-        -------
-        config: dict
-            The final parsed configuration as a python dictionnary.
-            Using priority orders: inline configuration, configuration file, default configuration
-            
-        """
+    Raises
+    ------
+    FileNotFoundError
+        The configuration file is not found at the indicated path.
+        Check that you gave the correct path, and that it is a str.
+        If you give a relative path, it must be relative to the run script path.
+    
+    Returns
+    -------
+    config: dict
+        The final parsed configuration as a python dictionnary.
+        Using priority orders: inline configuration, configuration file, default configuration
+        
+    """
     if config_path != "" and not Path(config_path).exists():
         raise FileNotFoundError(f"Configuration file {config_path} not found.")
 
@@ -596,20 +596,20 @@ def merge_kg(kg_list: List[KnowledgeGraph],
     Arguments
     ---------
     kg_list: List[KnowledgeGraph]
-        The list of all KG to be merged
+        The list of all knowledge graphs to be merged.
     complete_graphindices: bool, default to False
         Whether or not the removed_triplets tensor should be integrated into the final KG's graphindices.
 
-        Raises
-        ------
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
-        error_name
-            TODO.What_that_means_comma_causes_comma_and_fixes_if_easy
+    Raises
+    ------
+    AssertionError #1
+        Knowledge graphs in kg_list must have the same node_to_index (ent2ix).
+    AssertionError #2
+        Knowledge graphs in kg_list must have the same edge_to_index (rel2ix).
+    AssertionError #3
+        Knowledge graphs in kg_list must have the same node_type_to_index (nt2ix).
+    AssertionError #4
+        Knowledge graphs in kg_list must have the same triplet_types.
     
     Returns
     -------

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -682,7 +682,7 @@ def get_average_heads_per_tail(graphindices: Tensor) -> Dict[float, float]:
     average_heads_per_tail: Dict[float,float]
         Keys: relation indices; Values: average number of heads per tail
     """
-    dataframe = DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
     dataframe = dataframe.groupby(["edge", "tail"]).count().groupby("edge").mean()
     dataframe.reset_index(inplace=True)
     return {dataframe.loc[i].values[0]: dataframe.loc[i].values[1] for i in dataframe.index}

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -9,7 +9,7 @@ import logging
 import pickle
 from pathlib import Path
 from importlib.resources import open_binary
-from typing import List, Tuple, Literal
+from typing import List, Tuple, Literal, Dict
 
 import pandas as pd 
 import numpy as np
@@ -702,7 +702,7 @@ def get_average_tails_per_head(graphindices: Tensor) -> Dict[float, float]:
     average_tails_per_head: Dict[float,float]
         Keys: relation indices; Values: average number of tails per head
     """
-    dataframe = DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
     dataframe = dataframe.groupby(["head", "edge"]).count().groupby("edge").mean()
     dataframe.reset_index(inplace=True)
     return {dataframe.loc[i].values[0]: dataframe.loc[i].values[1] for i in dataframe.index}

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -1,5 +1,6 @@
 """
 Utility functions for Knowledge Graph manipulation, data visualisation or file handling.
+
 """
 
 import os
@@ -90,36 +91,36 @@ def set_config_key( key: str,
                     inline: dict | None = None
                     ) -> str | int | list | dict:
     """
-        TODO.What_the_function_does_about_globally
+    TODO.What_the_function_does_about_globally
 
-        References
-        ----------
-        TODO
+    References
+    ----------
+    TODO
 
-        Arguments
-        ---------
-        default: dict
-            The default parsed configuration as a python dictionnary.
-        config: dict, optional
-            TODO.What_that_argument_is_or_does
-        inline: dict, optional
-            The inline parsed configuration as a python dictionnary.
+    Arguments
+    ---------
+    default: dict
+        The default parsed configuration as a python dictionnary.
+    config: dict, optional
+        The configuration parsed from the config file.
+    inline: dict, optional
+        The inline parsed configuration as a python dictionnary.
 
-        Raises
-        ------
-        ValueError
-            A parameter without a default value is required but not set.
+    Raises
+    ------
+    ValueError
+        A parameter without a default value is required but not set.
 
-        Returns
-        -------
-        inline_value: TODO.type
-            TODO.What_that_variable_is_or_does
-        config_value: TODO.type
-            TODO.What_that_variable_is_or_does
-        default[key]: TODO.type
-            TODO.What_that_variable_is_or_does
-            
-        """
+    Returns
+    -------
+    inline_value: TODO.type
+        TODO.What_that_variable_is_or_does
+    config_value: TODO.type
+        TODO.What_that_variable_is_or_does
+    default[key]: TODO.type
+        TODO.What_that_variable_is_or_does
+    
+    """
     if inline is not None and key in inline:
         inline_value = inline[key]
     else:
@@ -233,12 +234,12 @@ def extract_node_type(node_name: str):
     Arguments
     ---------
     node_name: str
-        TODO.What_that_argument_is_or_does
+        The name of the node to extract the type from.
 
     Returns
     -------
     node_type: str
-        TODO.What_that_variable_is_or_does
+        The node type extracted.
     
     """
     return node_name.split("_")[0]
@@ -638,7 +639,9 @@ def merge_kg(kg_list: List[KnowledgeGraph],
         triplet_types = first_kg.triplet_types
     )
 
-def get_dictionary_mapping(dataframe: pd.DataFrame, nodes = True) -> Dict[str, int]:
+def get_dictionary_mapping( dataframe: pd.DataFrame,
+                            nodes = True
+                            ) -> Dict[str, int]:
     """
     Build the dictionary used to map either the node or edge identifiers to their index in the graph.
 
@@ -681,11 +684,14 @@ def get_average_heads_per_tail(graphindices: Tensor) -> Dict[float, float]:
     -------
     average_heads_per_tail: Dict[float,float]
         Keys: relation indices; Values: average number of heads per tail
+        
     """
-    dataframe = DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
+    dataframe = DataFrame(graphindices.T.cpu().numpy(), columns = ["head","tail","edge","triplet"])
     dataframe = dataframe.groupby(["edge", "tail"]).count().groupby("edge").mean()
-    dataframe.reset_index(inplace=True)
+    dataframe.reset_index(inplace = True)
+    
     return {dataframe.loc[i].values[0]: dataframe.loc[i].values[1] for i in dataframe.index}
+
 
 def get_average_tails_per_head(graphindices: Tensor) -> Dict[float, float]:
     """

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -557,7 +557,7 @@ def filter_scores(  scores: Tensor,
     -------
     filtered_scores: torch.Tensor
         Tensor of shape [batch_size, n] with -Inf values for all true node/edge index except the ones being predicted.
-        
+    
     """
     batch_size = scores.shape[0]
     filtered_scores = scores.clone()
@@ -637,7 +637,8 @@ def merge_kg(kg_list: List[KnowledgeGraph],
         edge_to_index = first_kg.edge_to_index,
         node_type_to_index = first_kg.node_type_to_index,
         triplet_types = first_kg.triplet_types
-    )
+        )
+
 
 def get_dictionary_mapping( dataframe: pd.DataFrame,
                             nodes = True
@@ -662,15 +663,19 @@ def get_dictionary_mapping( dataframe: pd.DataFrame,
     Notes
     -----
     This function is adapted from the torchkge.utils.operations.get_dictionaries() from the TorchKGE package.
+    
     """
     if nodes:
         unique_nodes = list(set(dataframe["head"].unique()).union(set(dataframe["tail"]).unique()))
         return {node: index for index, node in enumerate(sorted(unique_nodes))}
+    
     else:
         unique_edges = list(dataframe["edge"].unique())
         return {edge: index for index, edge in enumerate(sorted(unique_edges))}
 
-def get_average_heads_per_tail(graphindices: Tensor) -> Dict[float, float]:
+
+def get_average_heads_per_tail( graphindices: Tensor
+                                ) -> Dict[float, float]:
     """
     Get the average number of heads per tail across each edges.
 
@@ -686,14 +691,15 @@ def get_average_heads_per_tail(graphindices: Tensor) -> Dict[float, float]:
         Keys: relation indices; Values: average number of heads per tail
         
     """
-    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head","tail","edge","triplet"])
     dataframe = dataframe.groupby(["edge", "tail"]).count().groupby("edge").mean()
     dataframe.reset_index(inplace = True)
     
     return {dataframe.loc[i].values[0]: dataframe.loc[i].values[1] for i in dataframe.index}
 
 
-def get_average_tails_per_head(graphindices: Tensor) -> Dict[float, float]:
+def get_average_tails_per_head( graphindices: Tensor
+                                ) -> Dict[float, float]:
     """
     Get the average number of tails per head across each edges.
 
@@ -707,13 +713,17 @@ def get_average_tails_per_head(graphindices: Tensor) -> Dict[float, float]:
     -------
     average_tails_per_head: Dict[float,float]
         Keys: relation indices; Values: average number of tails per head
+    
     """
-    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns=["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head","tail","edge","triplet"])
     dataframe = dataframe.groupby(["head", "edge"]).count().groupby("edge").mean()
-    dataframe.reset_index(inplace=True)
+    dataframe.reset_index(inplace = True)
+    
     return {dataframe.loc[i].values[0]: dataframe.loc[i].values[1] for i in dataframe.index}
 
-def get_bernoulli_probabilities(knowledge_graph: KnowledgeGraph) -> Dict[float, float]:
+
+def get_bernoulli_probabilities(knowledge_graph: KnowledgeGraph
+                                ) -> Dict[float, float]:
     """
     Evaluate the Bernoulli probabilities for negative sampling as in the
     TransH original paper by Wang et al. (2014).
@@ -727,6 +737,7 @@ def get_bernoulli_probabilities(knowledge_graph: KnowledgeGraph) -> Dict[float, 
     -------
     bernoulli_probabilities: Dict[int, float]
         Sampled probabilities of tails for each head. Keys: edge indices; Values: probabilities.
+    
     """
     heads_per_tail = get_average_heads_per_tail(knowledge_graph.graphindices)
     tails_per_head = get_average_tails_per_head(knowledge_graph.graphindices)

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -637,3 +637,32 @@ def merge_kg(kg_list: List[KnowledgeGraph],
         node_type_to_index = first_kg.node_type_to_index,
         triplet_types = first_kg.triplet_types
     )
+
+def get_dictionary_mapping(dataframe: pd.DataFrame, nodes = True) -> Dict[str, int]:
+    """
+    Build the dictionary used to map either the node or edge identifiers to their index in the graph.
+
+    Arguments
+    ---------
+    dataframe: pd.DataFrame
+        Pandas dataframe containing at least three columns : "head", "edge" and "tail".
+        Other columns are ignored.
+    nodes: bool, optional, default to True
+        If True will build the dictionary for the nodes mapping, otherwise will build
+        the dictionary for the edge mapping.
+    
+    Returns
+    -------
+    node_to_index or edge_to_index: Dict[str, int]
+        Mapping dictionary for nodes or edges.
+
+    Notes
+    -----
+    This function is adapted from the torchkge.utils.operations.get_dictionaries() from the TorchKGE package.
+    """
+    if nodes:
+        unique_nodes = list(set(dataframe["head"].unique()).union(set(dataframe["tail"]).unique()))
+        return {node: index for index, node in enumerate(sorted(unique_nodes))}
+    else:
+        unique_edges = list(dataframe["edge"].unique())
+        return {edge: index for index, edge in enumerate(sorted(unique_edges))}

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -365,11 +365,9 @@ def count_triplets( kg1: KnowledgeGraph,
     Returns
     -------
     duplicate_count: int
-        Number of triplets in kg2 that have their duplicate triplet
-        in kg1
+        Number of triplets in kg2 that have their duplicate triplet in kg1.
     reverse_duplicate_count: int
-        Number of triplets in kg2 that have their reverse duplicate
-        triplet in kg1.
+        Number of triplets in kg2 that have their reverse duplicate triplet in kg1.
         
     """
     duplicate_count = 0
@@ -604,11 +602,11 @@ def merge_kg(kg_list: List[KnowledgeGraph],
     Raises
     ------
     AssertionError #1
-        Knowledge graphs in kg_list must have the same node_to_index (ent2ix).
+        Knowledge graphs in kg_list must have the same node_to_index.
     AssertionError #2
-        Knowledge graphs in kg_list must have the same edge_to_index (rel2ix).
+        Knowledge graphs in kg_list must have the same edge_to_index.
     AssertionError #3
-        Knowledge graphs in kg_list must have the same node_type_to_index (nt2ix).
+        Knowledge graphs in kg_list must have the same node_type_to_index.
     AssertionError #4
         Knowledge graphs in kg_list must have the same triplet_types.
     
@@ -621,9 +619,9 @@ def merge_kg(kg_list: List[KnowledgeGraph],
     first_kg = kg_list[0]
     for kg in kg_list:
         kg.clean()
-    assert all(first_kg.node_to_index == kg.node_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different node_to_index (ent2ix)."
-    assert all(first_kg.edge_to_index == kg.edge_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different edge_to_index (rel2ix)."
-    assert all(first_kg.node_type_to_index == kg.node_type_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different node_type_to_index (nt2ix)."
+    assert all(first_kg.node_to_index == kg.node_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different node_to_index."
+    assert all(first_kg.edge_to_index == kg.edge_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different edge_to_index."
+    assert all(first_kg.node_type_to_index == kg.node_type_to_index for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different node_type_to_index."
     assert all(first_kg.triplet_types == kg.triplet_types for kg in kg_list[1:]), "Cannot merge KnowledgeGraph with different triplet_types."
 
     new_graphindices = cat([kg.graphindices for kg in kg_list], dim = 1)
@@ -688,10 +686,11 @@ def get_average_heads_per_tail( graphindices: Tensor
     Returns
     -------
     average_heads_per_tail: Dict[float,float]
-        Keys: relation indices; Values: average number of heads per tail
+        Keys: relation indices
+        Values: average number of heads per tail
         
     """
-    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head", "tail", "edge", "triplet"])
     dataframe = dataframe.groupby(["edge", "tail"]).count().groupby("edge").mean()
     dataframe.reset_index(inplace = True)
     
@@ -715,7 +714,7 @@ def get_average_tails_per_head( graphindices: Tensor
         Keys: relation indices; Values: average number of tails per head
     
     """
-    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head","tail","edge","triplet"])
+    dataframe = pd.DataFrame(graphindices.T.cpu().numpy(), columns = ["head", "tail", "edge", "triplet"])
     dataframe = dataframe.groupby(["head", "edge"]).count().groupby("edge").mean()
     dataframe.reset_index(inplace = True)
     
@@ -732,6 +731,11 @@ def get_bernoulli_probabilities(knowledge_graph: KnowledgeGraph
     ---------
     knowledge_graph: kgate.KnowledgeGraph
         The knowledge graph to sample bernoulli probabilities from.
+
+    Raises
+    ------
+    AssertionError
+        TODO.errors
     
     Returns
     -------


### PR DESCRIPTION
## What are the changes for using KGATE?

While compatibility with TorchKGE is conserved, there is less dependency on it and decoders do not inherit from torchKGE classes anymore, and thus don't have the exact same attributes (replaced by similar with names consistent with the rest of KGATE). Beside that, usage should be unaltered.

## Why am I making these changes?
With the recent archiving of TorchKGE, it became clear that the tool will not receive any update, and won't fix its shortcomings. Thus, decision was made to cease the strategy of "not rebuilding the wheel at all cost". 

## What are the changes from a developer perspective?

All the places where the TorchKGE library was used and considered a liability, either because of the naming scheme conflicts between it and KGATE or the absence of strong typing, the call to the external library has been replaced by a KGATE version. This includes: 
- `torchkge.data_utils.operations.get_dictionaries` has been replaced by `kgate.utils.get_dictionary_mapping`. Return type is unchanged, but the function now expects the dataframe to have "head", "tail" and "edge" headers instead of "from", "to" and "rel".
- New interfaces have been written for all three families of decoders : `TranslationalDecoder`, `BilinearDecoder` and `ConvolutionalDecoder`. They are inspired by the TorchKGE equivalent: `TranslationalModel`, and `BilinearModel`. The TorchKGE top-level interface `Model` has not been reimplemented, but could be if deemed relevant. 
- Decoders now implement all their required methods. While it introduces duplicated code, it was considered necessary to improve readability and understanding of the inner workings of KGATE, and keep the interfaces truly separated from the actual implementation.
- Decoder methods `normalize_embeddings` and `get_embeddings` are now optional, returning `None` if not implemented.
- TorchKGE decoder method `inference_scoring_function` has been implemented as `inference_score` to keep consistency with the `score` method.
- The `Architect` no longer inherits from TorchKGE `Model`, but directly from PyTorch `Module`.
- Docstrings have been updated accordingly.

## How to test the changes?

Running KGATE from the Architect should be the same as before, with slight naming conventions changes. If old scripts no longer work after updating the variable names, bugs have been introduced by the changes.

## Checklist
- [x] **I'm using `dev` as my base branch**
- [x] There is no overlap with another PR
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com//BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I maintained consistency with the project's text
  - [x] Variables have consistent names
  - [x] All comments are in American English
- [ ] I have tested the changes manually

<!--
TODO, rework/add: for when the project has tests
- [ ] The full test suite still passes (`pnpm test:silent`)
  - [ ] I have created new automated tests (`pytest tests/`) or updated existing tests related to the PR's changes
-->