### PR TITLE
[Feat] add set_metadata method to architect

### DIFF
--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -304,10 +304,10 @@ class Architect(Module):
         """
         Set the node metadata of the knowledge graph.
 
-        This function accepts either a pandas dataframe or the path to a csv file as input.
+        This function accepts either a pandas DataFrame or the path to a CSV file as input.
         It must have at least columns:
-        - "id" which uses the same identifiers as the knowledge graph.
-        - "type" which records the type of the corresponding node
+        - "id" which uses the same identifiers as the knowledge graph;
+        - "type" which records the type of the corresponding node.
         
         In addition, the metadata can have any number of supplementary columns that can be
         used to set the identity of the nodes for the associated :class:`~kgate.knowledgegraph.KnowledgeGraph`.
@@ -319,21 +319,21 @@ class Architect(Module):
         Alternatively, you can directly run the :func:`~kgate.knowledgegraph.KnowledgeGraph.add_metadata` method for a
         more fine-grained metadata management.
         
-        Argument
-        --------
+        Arguments
+        ---------
         metadata: pd.DataFrame or os.PathLike
             The metadata object, either as a pandas DataFrame or a path to a CSV file.
 
-        Returns
-        -------
+        Raises
+        ------
         pd.errors.InvalidColumnName
-            If the columns id and type are not present.
+            If the columns 'id' and 'type' are not present.
         ValueError
             If the CSV file uses an unsupported separator.
         TypeError
             If the metadata object is not of the correct type.
+            
         """
-
         match type(metadata):
             case pd.DataFrame:
                 if not set(["id", "type"]).issubset(metadata.keys()):

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -217,22 +217,11 @@ class Architect(Module):
             self.edge_embedding_dimensions = self.node_embedding_dimensions
         self.evaluation_batch_size: int = self.config["training"]["evaluation_batch_size"]
 
-        if metadata is not None and not set(["id", "type"]).issubset(metadata.keys()):
-            raise pd.errors.InvalidColumnName("The columns \"id\" and \"type\" must be present in the given metadata dataframe.")
+        self.metadata = None
+        if metadata is None:
+            metadata = self.config["metadata_csv"]
+        self.set_metadata(metadata = metadata)
         
-        self.metadata = metadata
-
-        if metadata is None and self.config["metadata_csv"] != "" and Path(self.config["metadata_csv"]).exists():
-            for separator in SUPPORTED_SEPARATORS:
-                try:
-                    self.metadata = pd.read_csv(self.config["metadata_csv"], sep = separator, usecols = ["type", "id"])
-                    break
-                except ValueError:
-                    continue
-        
-            if self.metadata is None:
-                raise ValueError(f"The metadata csv file uses a non supported separator. Supported separators are '{'\', \''.join(SUPPORTED_SEPARATORS)}'.")
-
         run_kg_preprocessing: bool = self.config["run_kg_preprocessing"]
 
         if run_kg_preprocessing:
@@ -311,6 +300,66 @@ class Architect(Module):
         
         return self.edge_embedding_dimensions
 
+    def set_metadata(self, metadata: pd.DataFrame | os.PathLike):
+        """
+        Set the node metadata of the knowledge graph.
+
+        This function accepts either a pandas dataframe or the path to a csv file as input.
+        It must have at least columns:
+        - "id" which uses the same identifiers as the knowledge graph.
+        - "type" which records the type of the corresponding node
+        
+        In addition, the metadata can have any number of supplementary columns that can be
+        used to set the identity of the nodes for the associated :class:`~kgate.knowledgegraph.KnowledgeGraph`.
+
+        If there is no knowledge graph associated with the Architect, the `architect.metadata` property will be used
+        to initialize them. If there is already a knowledge graph, it will update the knowledge graph with
+        the new metadata.
+
+        Alternatively, you can directly run the :func:`~kgate.knowledgegraph.KnowledgeGraph.add_metadata` method for a
+        more fine-grained metadata management.
+        
+        Argument
+        --------
+        metadata: pd.DataFrame or os.PathLike
+            The metadata object, either as a pandas DataFrame or a path to a CSV file.
+
+        Returns
+        -------
+        pd.errors.InvalidColumnName
+            If the columns id and type are not present.
+        ValueError
+            If the CSV file uses an unsupported separator.
+        TypeError
+            If the metadata object is not of the correct type.
+        """
+
+        match type(metadata):
+            case pd.DataFrame:
+                if not set(["id", "type"]).issubset(metadata.keys()):
+                    raise pd.errors.InvalidColumnName("The columns \"id\" and \"type\" must be present in the given metadata dataframe.")
+        
+                self.metadata = metadata
+            case os.PathLike:
+                if metadata != "" and Path(metadata).exists():
+                    # Fuzzy identification of separator.
+                    # TODO: find a cleaner way to do it
+                    for separator in SUPPORTED_SEPARATORS:
+                        try:
+                            self.metadata = pd.read_csv(metadata, sep = separator, usecols = ["type", "id"])
+                            break
+                        except ValueError:
+                            continue
+                
+                    if self.metadata is None:
+                        raise ValueError(f"The metadata csv file uses a non supported separator. Supported separators are '{'\', \''.join(SUPPORTED_SEPARATORS)}'.")
+            case _:
+                raise TypeError(f"Metadata can only be given as a pandas DataFrame or a path to a CSV file, but got {type(metadata)}")
+            
+        if self.metadata is not None and hasattr(self, "kg_train"):
+            for knowledge_graph in (self.kg_train, self.kg_val, self.kg_test):
+                knowledge_graph.add_metadata(self.metadata)
+            
 
     def initialize_encoder( self,
                             encoder_name: Literal["Default", "GCN", "GAT", "Node2Vec", ""] = "",


### PR DESCRIPTION
<!-- Once you have read these comments, you are free to remove them -->

<!-- Feel free to look at other PRs for examples -->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Ideally the title is less than or equal to 72 characters (GitHub cuts off commit titles longer than this length).

TODO, rework/add: See https://github.com/BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
implements(decoder): SpherE complete implementation
^           ^        ^
|           |        |__ Subject
|           |___________ Scope (optional)
|_______________________ Prefix
-->

<!--
Make sure that this PR is not overlapping with someone else's work.
Please try to keep the PR self-contained (don't change a bunch of unrelated things).
-->

<!--
The first section is mandatory if there are user-facing changes (it will be used as the base for a changelog entry).
The second and third section are mandatory.
-->

<!--
This PR template was inspired by https://github.com/pagefaultgames/pokerogue
-->

## What are the changes for using KGATE?
<!-- Summarize what the changes are from a user perspective on the application -->

Brings a new set_metadata method to the architect for easier metadata handling.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from an issue or another PR? Link to them if possible.
Explain why you believe this can enhance user experience.
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Currently, it is difficult to properly alter the metadata attribute after the architect has been created. This PR addresses this issue.

## What are the changes from a developer perspective?
<!--
Describe the codebase changes introduced by the PR.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

New method in architect.py, with a new preferred way to create or update the metadata.



## Checklist
- [ ] ~~**I'm using `dev` as my base branch**~~
- [x] There is no overlap with another PR
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com//BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I maintained consistency with the project's text
  - [x] Variables have consistent names
  - [x] All comments are in American English
- [x] I have tested the changes manually

<!--
TODO, rework/add: for when the project has tests
- [ ] The full test suite still passes (`pnpm test:silent`)
  - [ ] I have created new automated tests (`pytest tests/`) or updated existing tests related to the PR's changes
-->