### PR TITLE
[Docs] Fix the autodoc: `inference.md` as proof of concept

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ release = '0.1.13'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autodoc",
+extensions = ["sphinx.ext.autodoc2",
               "sphinx.ext.doctest",
               "sphinx.ext.napoleon",
               "sphinx.ext.apidoc",
@@ -34,8 +34,11 @@ myst_enable_extensions = [
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+autodoc2_packages = [{"auto_mode": False,},] # Enable manual mode, to manually specify which objects to document
+autodoc2_render_plugin = "myst" # Create all files with the “.md” extension, and thus docstrings will be interpreted as MyST by default
+
 autosummary_generate = True  # Enable autosummary to generate pages
-autodoc_default_flags = ['members']  # Automatically document class members
+#autodoc_default_flags = ['members']  # Automatically document class members
 epub_show_urls = "footnote"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ myst_enable_extensions = [
     "replacements",
     "deflist",
     "tasklist",
+    "fieldlist",
 ]
 
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ release = '0.1.13'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autodoc2",
+extensions = ["autodoc2",
               "sphinx.ext.doctest",
               "sphinx.ext.napoleon",
               "sphinx.ext.apidoc",
@@ -34,7 +34,13 @@ myst_enable_extensions = [
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-autodoc2_packages = [{"auto_mode": False,},] # Enable manual mode, to manually specify which objects to document
+
+autodoc2_packages = [
+    {
+        "path": "../src/kgate",
+        "auto_mode": False,  # Enable manual mode, to manually specify which objects to document
+    },
+]
 autodoc2_render_plugin = "myst" # Create all files with the “.md” extension, and thus docstrings will be interpreted as MyST by default
 
 autosummary_generate = True  # Enable autosummary to generate pages

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ knowledge_graph
 preprocessing_workflow
 data_leakage
 preprocessors
+inference
 encoders
 decoders
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,4 +1,4 @@
-# `inference.py`
+# Inference
 
 ## Inference_KG
 ```{autodoc2-docstring} kgate.inference.Inference_KG

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,26 +1,26 @@
-# Inference
+# `inference.py`
 
-## Interface Class for Inference
+## Inference_KG
 ```{autodoc2-docstring} kgate.inference.Inference_KG
     
 ```
 
-## Edge Inference Class
+## EdgeInference
 ```{autodoc2-docstring} kgate.inference.EdgeInference
 
 ```
 
-### Edge Inference `evaluate` Function
+### evaluate
 ```{autodoc2-docstring} kgate.inference.EdgeInference.evaluate
 
 ```
 
-## Node Inference Class
+## NodeInference
 ```{autodoc2-docstring} kgate.inference.NodeInference
     
 ```
 
-### Node Inference `evaluate` Function
+### evaluate
 ```{autodoc2-docstring} kgate.inference.NodeInference.evaluate
     
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -3,14 +3,14 @@
 ## Placeholder text for tests
 
 ```{autoclass} kgate.inference.Inference_KG
-    
+    :no-index-entry:
 ```
 
 
 ## Lorem ipsum
 
 ```{autoclass} kgate.inference.EdgeInference
-    :members:
+    
 ```
 
 
@@ -18,5 +18,5 @@
 
 
 ```{autoclass} kgate.inference.NodeInference
-    :members:
+    
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -3,13 +3,13 @@
 ## Placeholder text for tests
 
 ```{autoclass} kgate.inference.Inference_KG
-    :no-index-entry:
+    :no-index:
 ```
 
 
 ## Lorem ipsum
 
-```{autoclass} kgate.inference.EdgeInference
+```{autodoc2-docstring} kgate.inference.EdgeInference
     
 ```
 
@@ -17,6 +17,6 @@
 ## Hello world
 
 
-```{autoclass} kgate.inference.NodeInference
-    
+```{autodoc2-docstring} kgate.inference.NodeInference
+    :literal:
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,26 +1,26 @@
 # Inference
 
-% Interface class for inference, has `__init__`, `__len__` and `__getitem__`
+## Interface Class for Inference
 ```{autodoc2-docstring} kgate.inference.Inference_KG
     
 ```
 
-% Edge inference class
+## Edge Inference Class
 ```{autodoc2-docstring} kgate.inference.EdgeInference
 
 ```
 
-% Edge inference evaluate function
+### Edge Inference `evaluate` Function
 ```{autodoc2-docstring} kgate.inference.EdgeInference.evaluate
 
 ```
 
-% Node inference class
+## Node Inference Class
 ```{autodoc2-docstring} kgate.inference.NodeInference
     
 ```
 
-% Node inference evaluate function
+### Node Inference `evaluate` Function
 ```{autodoc2-docstring} kgate.inference.NodeInference.evaluate
     
 ```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,0 +1,17 @@
+# Inference
+
+Placeholder text for tests
+
+```{autoclass} kgate.inference.Inference_KG
+    :members:
+```
+
+
+Lorem ipsum
+
+```{autoclass} kgate.inference.EdgeInference
+    :members:
+```
+
+
+Hello world

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,17 +1,22 @@
 # Inference
 
-Placeholder text for tests
+## Placeholder text for tests
 
 ```{autoclass} kgate.inference.Inference_KG
-    :members:
+    
 ```
 
 
-Lorem ipsum
+## Lorem ipsum
 
 ```{autoclass} kgate.inference.EdgeInference
     :members:
 ```
 
 
-Hello world
+## Hello world
+
+
+```{autoclass} kgate.inference.NodeInference
+    :members:
+```

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,22 +1,26 @@
 # Inference
 
-## Placeholder text for tests
-
-```{autoclass} kgate.inference.Inference_KG
-    :no-index:
-```
-
-
-## Lorem ipsum
-
-```{autodoc2-docstring} kgate.inference.EdgeInference
+% Interface class for inference, has `__init__`, `__len__` and `__getitem__`
+```{autodoc2-docstring} kgate.inference.Inference_KG
     
 ```
 
+% Edge inference class
+```{autodoc2-docstring} kgate.inference.EdgeInference
 
-## Hello world
+```
 
+% Edge inference evaluate function
+```{autodoc2-docstring} kgate.inference.EdgeInference.evaluate
 
+```
+
+% Node inference class
 ```{autodoc2-docstring} kgate.inference.NodeInference
-    :literal:
+    
+```
+
+% Node inference evaluate function
+```{autodoc2-docstring} kgate.inference.NodeInference.evaluate
+    
 ```

--- a/docs/preprocessing_workflow.md
+++ b/docs/preprocessing_workflow.md
@@ -17,13 +17,13 @@ If a data structure is not supported yet, you can ask for it to be added or impl
 
 ## Filtering out duplicate triples
 
-*related parameter: preprocessing.remove_duplicate_triples*
+*related parameter: :func:`~kgate.preprocessing.remove_duplicate_triplets`*
 
 Sometimes, most commonly when a **knowledge graph** is built using an automated system, the exact same triple *(a,r,b)*. The presence of duplicates brings a lot of possible biases, so they are detected and entirely removed from the dataset.
 
 ## Filtering out reverse triples
 
-*related parameters: preprocessing.flag_near_duplicate_relations
+*related parameters: :func:`~kgate.preprocessing.flag_near_duplicate_relations`*
 
 For every relation, if a triple *(a,r,b)* also has its reverse *(b,r,a)* in the **knowledge graph**, the second instance is flagged and taken out of the dataset. Indeed, some models cannot handle symmetric relationships, and the reverse relation might have a slightly different semantic meaning.
 

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -17,15 +17,19 @@ from .utils import filter_scores
 
 class Inference_KG(Dataset):
     """
-    ## Interface Class for Inference
-      ~ Subset of a KG used for inference.
+    <span style="background-color:#06402B"> 
+    **Description**
+    </span>
+      ~ Subset of a KG used for ==inference==.
       ~ This class inherits from the PyTorch [`utils.data.Dataset`](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
 
     **Arguments**
       ~ **first_index_tensor:** torch.Tensor
            The first tensor with indices of the edges or nodes (from the knowledge graph).
       ~ **second_index_tensor:** torch.Tensor
+           <span style="background-color:#06402B"> 
            The second tensor with indices of the edges or nodes (from the knowledge graph).
+           </span>
 
     **Attributes**
       ~ **first_index_tensor:** torch.Tensor
@@ -33,13 +37,17 @@ class Inference_KG(Dataset):
       ~ **second_index_tensor:** torch.Tensor
            The second tensor with indices of the edges or nodes (from the knowledge graph).
     
+    <span style="color:red">
     **Raises**
+    </span>
       ~ **AssertionError**
            Both index tensors must be of the same size.
 
     **Notes**
       ~ Either both tensors are nodes, or they are node and edge.
+      <span style="color:red">
       ~ The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
+      </span>
     
     """
     def __init__(self,
@@ -63,7 +71,7 @@ class Inference_KG(Dataset):
 
 class EdgeInference:
     """
-    ## Edge Inference Class
+    **Description**
     - Use trained embedding model to infer missing edges in triplets.
 
     **Arguments**
@@ -91,7 +99,7 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        ### Edge Inference `evaluate` Function
+        **Description**
           : TODO.What_the_function_does_about_globally
 
         **Arguments**
@@ -122,6 +130,8 @@ class EdgeInference:
           : **scores:** torch.Tensor, shape [batch_size, n]
               Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
+        ---
+        
         """
         with torch.no_grad():
             device = edge_embeddings.weight.device
@@ -180,14 +190,15 @@ class EdgeInference:
 
 class NodeInference:
     """
-    ## Node Inference Class
-      ~ Use trained embedding model to infer missing nodes in triplets.
+    **Description**
+    
+    Use trained embedding model to infer missing nodes in triplets.
 
     **Arguments**
       ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
-    **Attributes**
+    ***Attributes***
       ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
@@ -210,7 +221,7 @@ class NodeInference:
                 verbose: bool = True,
                 **_):
         """
-        ### Node Inference `evaluate` Function
+        **Description**
           : Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
         **Arguments**
@@ -231,6 +242,7 @@ class NodeInference:
           : **node_embeddings:** nn.ParameterList, keyword-only
           : >    A list containing all embeddings for each node type.
           : >    keys: node type index
+          : >
           : >    values: tensors of shape (node_count, embedding_dimensions)
           : **edge_embeddings:** nn.Embedding, keyword-only
           : >    A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -21,7 +21,7 @@ class Inference_KG(Dataset):
     <strong>Description</strong>
     </span>
     
-    Subset of a KG used for ==inference==.
+    Subset of a KG used for inference.
     
     This class inherits from the PyTorch [`utils.data.Dataset`](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
 
@@ -29,33 +29,37 @@ class Inference_KG(Dataset):
     <strong>Arguments</strong>
     </span>
     
-      : **first_index_tensor:** torch.Tensor
-      : >    The first tensor with indices of the edges or nodes (from the knowledge graph).
-      : **second_index_tensor:** torch.Tensor
-      : >    The second tensor with indices of the edges or nodes (from the knowledge graph).
+    **first_index_tensor:** torch.Tensor
+    : The first tensor with indices of the edges or nodes (from the knowledge graph).
+    **second_index_tensor:** torch.Tensor
+    : The second tensor with indices of the edges or nodes (from the knowledge graph).
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-    : **first_index_tensor:** torch.Tensor
-    : >    The first tensor with indices of the edges or nodes (from the knowledge graph).
-    : **second_index_tensor:** torch.Tensor
-    : >    The second tensor with indices of the edges or nodes (from the knowledge graph).
+    **first_index_tensor:** torch.Tensor
+    : The first tensor with indices of the edges or nodes (from the knowledge graph).
+    
+    **second_index_tensor:** torch.Tensor
+    : The second tensor with indices of the edges or nodes (from the knowledge graph).
     
     <span style="color:#8B0000"> 
     <strong>Raises</strong>
     </span>
     
-    : **AssertionError**
-    : >    Both index tensors must be of the same size.
+    **AssertionError**
+    : Both index tensors must be of the same size.
 
     <span style="color:#8B0000"> 
     <strong>Notes</strong>
     </span>
     
-    : Either both tensors are nodes, or they are node and edge.   
-    : The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
+    Either both tensors are nodes, or they are node and edge.   
+    
+    The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
+        
+    ---
     
     """
     def __init__(self,
@@ -89,15 +93,15 @@ class EdgeInference:
     <strong>Arguments</strong>
     </span>
     
-    - **kg:** KnowledgeGraph
-         Knowledge graph on which the inference will be done.
+    **kg:** KnowledgeGraph
+    : →  Knowledge graph on which the inference will be done.
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-    - **kg:** KnowledgeGraph
-        →  Knowledge graph on which the inference will be done.
+    **kg:** KnowledgeGraph
+    : →  Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -127,36 +131,45 @@ class EdgeInference:
         <strong>Arguments</strong>
         </span>
 
-          : **head_indices:** torch.Tensor
-              The indices of the head nodes (from the knowledge graph).
-          : **tail_indices:** torch.Tensor
-              The indices of the tail nodes (from the knowledge graph).
-          : **top_k:** int, keyword-only
-              Indicate the number of top predictions to return.
-          : **batch_size:** int, keyword-only
-              Size of the current batch.
-          : **encoder:** DefaultEncoder or GNN, keyword-only
-              Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-          : **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
-              Decoder model to evaluate.
-          : **node_embeddings:** nn.ParameterList, keyword-only
-              A list containing all embeddings for each node type.
-                  keys: node type index
-                  values: tensors of shape (node_count, embedding_dimensions)
-          : ** edge_embeddings:** nn.Embedding, keyword-only
-              A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-          : **verbose:** bool, default to True, keyword-only
-              Indicate whether a progress bar should be displayed during evaluation.
+        **head_indices:** torch.Tensor
+        : The indices of the head nodes (from the knowledge graph).
+        
+        **tail_indices:** torch.Tensor
+        : The indices of the tail nodes (from the knowledge graph).
+        
+        **top_k:** int, keyword-only
+        : Indicate the number of top predictions to return.
+        
+        **batch_size:** int, keyword-only
+        : Size of the current batch.
+        
+        **encoder:** DefaultEncoder or GNN, keyword-only
+        : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+        
+        **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+        : Decoder model to evaluate.
+        
+        **node_embeddings:** nn.ParameterList, keyword-only
+        : A list containing all embeddings for each node type.
+          : keys: node type index
+          : values: tensors of shape (node_count, embedding_dimensions)
+        
+        ** edge_embeddings:** nn.Embedding, keyword-only
+        : A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+        
+        **verbose:** bool, default to True, keyword-only
+        : Indicate whether a progress bar should be displayed during evaluation.
 
         <span style="color:#8B0000"> 
         <strong>Returns</strong>
         </span>
 
-          : **predictions** *(torch.Tensor)*
-              % TODO.What_that_variable_is_or_does
-              *Missing documentation*
-          : **scores** *(torch.Tensor, shape [batch_size, n])*
-              Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+        **predictions** *(torch.Tensor)*
+        % TODO.What_that_variable_is_or_does
+        : *Missing documentation*
+        
+        **scores** *(torch.Tensor, shape [batch_size, n])*
+        : Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         ---
         
@@ -228,15 +241,15 @@ class NodeInference:
     <strong>Arguments</strong>
     </span>
     
-      ~ **kg:** KnowledgeGraph
-      ~     Knowledge graph on which the inference will be done.
+    **kg:** KnowledgeGraph
+    : Knowledge graph on which the inference will be done.
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-      ~ **kg:** KnowledgeGraph
-      ~     Knowledge graph on which the inference will be done.
+    **kg:** KnowledgeGraph
+    : Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -261,44 +274,55 @@ class NodeInference:
         <strong>Description</strong>
         </span>
     
-          : Predict the missing node of a triplet where either head and edge or edge and tail are known.
+        Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
         <span style="color:#8B0000"> 
         <strong>Arguments</strong>
         </span>
         
-          : **node_indices:** torch.Tensor
-          : >    The indices of nodes (from the knowledge graph).
-          : **edge_indices:** torch.Tensor
-          : >    The indices of edges (from the knowledge graph).
-          : **top_k:** int, keyword-only
-          : >    Indicate the number of top predictions to return.
-          : **missing_triplet_part:** Literal["head", "tail"], keyword-only
-          : >    String indicating if the missing nodes are the heads or the tails.
-          : **batch_size:** int, keyword-only
-          : >    Size of the current batch.
-          : **encoder:** DefaultEncoder or GNN, keyword-only
-          : >    Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-          : **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
-          : >    Decoder model to evaluate.
-          : **node_embeddings:** nn.ParameterList, keyword-only
-          : >    A list containing all embeddings for each node type.
-          : >    keys: node type index
-          : >
-          : >    values: tensors of shape (node_count, embedding_dimensions)
-          : **edge_embeddings:** nn.Embedding, keyword-only
-          : >    A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-          : **verbose:** bool, default to True, keyword-only
-          : >    Indicate whether a progress bar should be displayed during evaluation.
+        **node_indices:** torch.Tensor
+        : The indices of nodes (from the knowledge graph).
+        
+        **edge_indices:** torch.Tensor
+        : The indices of edges (from the knowledge graph).
+        
+        **top_k:** int, keyword-only
+        : Indicate the number of top predictions to return.
+        
+        **missing_triplet_part:** Literal["head", "tail"], keyword-only
+        : String indicating if the missing nodes are the heads or the tails.
+        
+        **batch_size:** int, keyword-only
+        : Size of the current batch.
+        
+        **encoder:** DefaultEncoder or GNN, keyword-only
+        : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+        
+        **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+        : Decoder model to evaluate.
+        
+        **node_embeddings:** nn.ParameterList, keyword-only
+        : A list containing all embeddings for each node type.
+          : keys: node type index
+          : 
+          : values: tensors of shape (node_count, embedding_dimensions)
+        
+        **edge_embeddings:** nn.Embedding, keyword-only
+        : A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+        
+        **verbose:** bool, default to True, keyword-only
+        : Indicate whether a progress bar should be displayed during evaluation.
 
         <span style="color:#8B0000"> 
         <strong>Returns</strong>
         </span>
         
-          : **predictions:** torch.Tensor
-          :   >  TODO.What_that_variable_is_or_does
-          : **scores:** torch.Tensor, shape [batch_size, n]
-          :   >  Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+        **predictions:** torch.Tensor
+        % TODO.What_that_variable_is_or_does
+        *Missing documentation*
+        
+        **scores:** torch.Tensor, shape [batch_size, n]
+        : Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
         
         """
         with torch.no_grad():

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -29,19 +29,20 @@ class Inference_KG(Dataset):
     <strong>Arguments</strong>
     </span>
     
-    **first_index_tensor:** torch.Tensor
+    **first_index_tensor** *(torch.Tensor)*
     : The first tensor with indices of the edges or nodes (from the knowledge graph).
-    **second_index_tensor:** torch.Tensor
+    
+    **second_index_tensor** *(torch.Tensor)*
     : The second tensor with indices of the edges or nodes (from the knowledge graph).
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-    **first_index_tensor:** torch.Tensor
+    **first_index_tensor** *(torch.Tensor)*
     : The first tensor with indices of the edges or nodes (from the knowledge graph).
     
-    **second_index_tensor:** torch.Tensor
+    **second_index_tensor** *(torch.Tensor)*
     : The second tensor with indices of the edges or nodes (from the knowledge graph).
     
     <span style="color:#8B0000"> 
@@ -93,15 +94,15 @@ class EdgeInference:
     <strong>Arguments</strong>
     </span>
     
-    **kg:** KnowledgeGraph
-    : →  Knowledge graph on which the inference will be done.
+    **kg** *(KnowledgeGraph)*
+    : Knowledge graph on which the inference will be done.
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-    **kg:** KnowledgeGraph
-    : →  Knowledge graph on which the inference will be done.
+    **kg** *(KnowledgeGraph)*
+    : Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -131,33 +132,33 @@ class EdgeInference:
         <strong>Arguments</strong>
         </span>
 
-        **head_indices:** torch.Tensor
+        **head_indices** *(torch.Tensor
         : The indices of the head nodes (from the knowledge graph).
         
-        **tail_indices:** torch.Tensor
+        **tail_indices** *(torch.Tensor)*
         : The indices of the tail nodes (from the knowledge graph).
         
-        **top_k:** int, keyword-only
+        **top_k** *(int, keyword-only)*
         : Indicate the number of top predictions to return.
         
-        **batch_size:** int, keyword-only
+        **batch_size** *(int, keyword-only)*
         : Size of the current batch.
         
-        **encoder:** DefaultEncoder or GNN, keyword-only
+        **encoder** *(DefaultEncoder or GNN, keyword-only)*
         : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
         
-        **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+        **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
         : Decoder model to evaluate.
         
-        **node_embeddings:** nn.ParameterList, keyword-only
+        **node_embeddings** *(nn.ParameterList, keyword-only)*
         : A list containing all embeddings for each node type.
           : keys: node type index
           : values: tensors of shape (node_count, embedding_dimensions)
         
-        ** edge_embeddings:** nn.Embedding, keyword-only
+        **edge_embeddings** *(nn.Embedding, keyword-only)*
         : A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
         
-        **verbose:** bool, default to True, keyword-only
+        **verbose** *(bool, default to True, keyword-only)*
         : Indicate whether a progress bar should be displayed during evaluation.
 
         <span style="color:#8B0000"> 
@@ -165,8 +166,8 @@ class EdgeInference:
         </span>
 
         **predictions** *(torch.Tensor)*
-        % TODO.What_that_variable_is_or_does
         : *Missing documentation*
+        % TODO.What_that_variable_is_or_does
         
         **scores** *(torch.Tensor, shape [batch_size, n])*
         : Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
@@ -241,14 +242,14 @@ class NodeInference:
     <strong>Arguments</strong>
     </span>
     
-    **kg:** KnowledgeGraph
+    **kg** *(KnowledgeGraph)*
     : Knowledge graph on which the inference will be done.
 
     <span style="color:#8B0000"> 
     <strong>Attributes</strong>
     </span>
     
-    **kg:** KnowledgeGraph
+    **kg** *(KnowledgeGraph)*
     : Knowledge graph on which the inference will be done.
 
     """
@@ -280,48 +281,47 @@ class NodeInference:
         <strong>Arguments</strong>
         </span>
         
-        **node_indices:** torch.Tensor
+        **node_indices** *(torch.Tensor)*
         : The indices of nodes (from the knowledge graph).
         
-        **edge_indices:** torch.Tensor
+        **edge_indices** *(torch.Tensor)*
         : The indices of edges (from the knowledge graph).
         
-        **top_k:** int, keyword-only
+        **top_k** *(int, keyword-only)*
         : Indicate the number of top predictions to return.
         
-        **missing_triplet_part:** Literal["head", "tail"], keyword-only
+        **missing_triplet_part** *(Literal["head", "tail"], keyword-only)*
         : String indicating if the missing nodes are the heads or the tails.
         
-        **batch_size:** int, keyword-only
+        **batch_size** *(int, keyword-only)*
         : Size of the current batch.
         
-        **encoder:** DefaultEncoder or GNN, keyword-only
+        **encoder** *(DefaultEncoder or GNN, keyword-only)*
         : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
         
-        **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+        **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only)*
         : Decoder model to evaluate.
         
-        **node_embeddings:** nn.ParameterList, keyword-only
+        **node_embeddings** *(nn.ParameterList, keyword-only)*
         : A list containing all embeddings for each node type.
           : keys: node type index
-          : 
           : values: tensors of shape (node_count, embedding_dimensions)
         
-        **edge_embeddings:** nn.Embedding, keyword-only
+        **edge_embeddings** *(nn.Embedding, keyword-only)*
         : A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
         
-        **verbose:** bool, default to True, keyword-only
+        **verbose** *(bool, default to True, keyword-only)*
         : Indicate whether a progress bar should be displayed during evaluation.
 
         <span style="color:#8B0000"> 
         <strong>Returns</strong>
         </span>
         
-        **predictions:** torch.Tensor
+        **predictions** *(torch.Tensor)*
         % TODO.What_that_variable_is_or_does
         *Missing documentation*
         
-        **scores:** torch.Tensor, shape [batch_size, n]
+        **scores** *(torch.Tensor, shape [batch_size, n])*
         : Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
         
         """

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -17,28 +17,27 @@ from .utils import filter_scores
 
 class Inference_KG(Dataset):
     """
-    Placeholder
+    **Placeholder**
       ~ Subset of a KG used for inference.
-      ~ This class inherits from the PyTorch `utils.data.Dataset` class:
-      ~ https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html
+      ~ This class inherits from the PyTorch [utils.data.Dataset](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
 
-    Arguments
+    **Arguments**
       ~ first_index_tensor: torch.Tensor
       ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
       ~ second_index_tensor: torch.Tensor
       ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
 
-    Attributes
+    **Attributes**
       ~ first_index_tensor: torch.Tensor
       ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
       ~ second_index_tensor: torch.Tensor
       ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
     
-    Raises
+    **Raises**
       ~ AssertionError
       ~     Both index tensors must be of the same size.
 
-    Notes
+    **Notes**
       ~ Either both tensors are nodes, or they are node and edge.
       ~ The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
     
@@ -67,11 +66,11 @@ class EdgeInference:
     **Placeholder**
       ~ Use trained embedding model to infer missing edges in triplets.
 
-    __**Arguments**__
+    **Arguments**
       ~ kg: KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
-    **__Attributes__**
+    **Attributes**
       ~ kg: KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
@@ -92,9 +91,10 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        TODO.What_the_function_does_about_globally
+        **Placeholder**
+          ~ TODO.What_the_function_does_about_globally
 
-        *Arguments*
+        **Arguments**
           ~ head_indices: torch.Tensor
           ~     The indices of the head nodes (from the knowledge graph).
 
@@ -117,7 +117,7 @@ class EdgeInference:
           ~ verbose: bool, default to True, keyword-only
           ~     Indicate whether a progress bar should be displayed during evaluation.
 
-        _Returns_
+        **Returns**
           ~ predictions: torch.Tensor
           ~     TODO.What_that_variable_is_or_does
           ~ scores: torch.Tensor, shape [batch_size, n]
@@ -181,13 +181,13 @@ class EdgeInference:
 
 class NodeInference:
     """
-    Use trained embedding model to infer missing entities in triples.
+      ~ Use trained embedding model to infer missing entities in triples.
 
-    ## Arguments
+    **Arguments**
       ~ kg: KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
-    ## __Attributes__
+    **Attributes**
       ~ kg: KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
@@ -210,9 +210,10 @@ class NodeInference:
                 verbose: bool = True,
                 **_):
         """
-        Predict the missing node of a triplet where either head and edge or edge and tail are known.
+        **plop**
+          ~ Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
-        # Arguments
+        **Arguments**
           ~ node_indices: torch.Tensor
           ~     The indices of nodes (from the knowledge graph).
           ~ edge_indices: torch.Tensor
@@ -236,7 +237,7 @@ class NodeInference:
           ~ verbose: bool, default to True, keyword-only
           ~     Indicate whether a progress bar should be displayed during evaluation.
 
-        ### Returns
+        **Returns**
           ~ predictions: torch.Tensor
           ~     TODO.What_that_variable_is_or_does
           ~ scores: torch.Tensor, shape [batch_size, n]

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -71,10 +71,8 @@ class EdgeInference:
     """
     Use trained embedding model to infer missing edges in triplets.
 
-    Arguments
-    ---------
-    kg: KnowledgeGraph
-        Knowledge graph on which the inference will be done.
+    :arg kg: Knowledge graph on which the inference will be done.
+    :type kg: KnowledgeGraph
 
     Attributes
     ----------
@@ -100,35 +98,41 @@ class EdgeInference:
         """
         TODO.What_the_function_does_about_globally
 
-        Arguments
-        ---------
-        head_indices: torch.Tensor
-            The indices of the head nodes (from the knowledge graph).
-        tail_indices: torch.Tensor
-            The indices of the tail nodes (from the knowledge graph).
-        top_k: int, keyword-only
-            Indicate the number of top predictions to return.
-        batch_size: int, keyword-only
-            Size of the current batch.
-        encoder: DefaultEncoder or GNN, keyword-only
-            Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
-            Decoder model to evaluate.
-        node_embeddings: nn.ParameterList, keyword-only
-            A list containing all embeddings for each node type.
+        :type head_indices: torch.Tensor
+        :arg head_indices: The indices of the head nodes (from the knowledge graph).
+        
+        :type tail_indices: torch.Tensor
+        :arg tail_indices: The indices of the tail nodes (from the knowledge graph).
+        
+        :type top_k: int, keyword-only
+        :arg top_k: Indicate the number of top predictions to return.
+        
+        :type batch_size: int, keyword-only
+        :arg batch_size: Size of the current batch.
+        
+        :type encoder: DefaultEncoder or GNN, keyword-only
+        :arg encoder: Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+        
+        :type decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+        :arg decoder: Decoder model to evaluate.
+        
+        :type node_embeddings: nn.ParameterList, keyword-only
+        :arg node_embeddings: A list containing all embeddings for each node type.
             keys: node type index
             values: tensors of shape (node_count, embedding_dimensions)
-        edge_embeddings: nn.Embedding, keyword-only
-            A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-        verbose: bool, default to True, keyword-only
-            Indicate whether a progress bar should be displayed during evaluation.
+        
+        :type edge_embeddings: nn.Embedding, keyword-only
+        :arg A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+        
+        :type verbose: bool, default to True, keyword-only
+        :arg verbose: Indicate whether a progress bar should be displayed during evaluation.
 
         Returns
         -------
-        predictions: torch.Tensor
-            TODO.What_that_variable_is_or_does
-        scores: torch.Tensor, shape [batch_size, n]
-            Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+        :rtype predictions: torch.Tensor
+        :returns predictions: TODO.What_that_variable_is_or_does
+        :rtype scores: torch.Tensor, shape [batch_size, n]
+        :returns scores: Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         """
         with torch.no_grad():

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -64,15 +64,15 @@ class Inference_KG(Dataset):
 
 class EdgeInference:
     """
-    Placeholder
+    **Placeholder**
       ~ Use trained embedding model to infer missing edges in triplets.
 
-    Arguments
-      ~ Knowledge graph on which the inference will be done.
-      ~     KnowledgeGraph
+    __**Arguments**__
+      ~ kg: KnowledgeGraph
+      ~     Knowledge graph on which the inference will be done.
 
-    Attributes
-      ~ KnowledgeGraph
+    **__Attributes__**
+      ~ kg: KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
     """
@@ -92,43 +92,36 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        :Placeholder: TODO.What_the_function_does_about_globally
+        TODO.What_the_function_does_about_globally
 
-        :Arguments:
-            :head_indices: torch.Tensor
-                The indices of the head nodes (from the knowledge graph).
+        *Arguments*
+          ~ head_indices: torch.Tensor
+          ~     The indices of the head nodes (from the knowledge graph).
 
-            :tail_indices: torch.Tensor
-                The indices of the tail nodes (from the knowledge graph).
+          ~ tail_indices: torch.Tensor
+          ~     The indices of the tail nodes (from the knowledge graph).
+          ~ top_k: int, keyword-only
+          ~     Indicate the number of top predictions to return.
+          ~ batch_size: int, keyword-only
+          ~     Size of the current batch.
+          ~ encoder: DefaultEncoder or GNN, keyword-only
+          ~     Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+          ~ decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+          ~     Decoder model to evaluate.
+          ~ node_embeddings: nn.ParameterList, keyword-only
+          ~     A list containing all embeddings for each node type.
+          ~         keys: node type index
+          ~         values: tensors of shape (node_count, embedding_dimensions)
+          ~ edge_embeddings: nn.Embedding, keyword-only
+          ~     A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+          ~ verbose: bool, default to True, keyword-only
+          ~     Indicate whether a progress bar should be displayed during evaluation.
 
-            :top_k: int, keyword-only
-                Indicate the number of top predictions to return.
-
-            :batch_size: int, keyword-only
-                Size of the current batch.
-
-            :encoder: DefaultEncoder or GNN, keyword-only
-                Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-
-            :decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
-                Decoder model to evaluate.
-
-            :node_embeddings: nn.ParameterList, keyword-only
-                node_embeddings: A list containing all embeddings for each node type.
-                    keys: node type index
-                    values: tensors of shape (node_count, embedding_dimensions)
-
-            :edge_embeddings: nn.Embedding, keyword-only
-                A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-
-            :verbose: bool, default to True, keyword-only
-                Indicate whether a progress bar should be displayed during evaluation.
-
-        :Returns:
-            :predictions: torch.Tensor
-                TODO.What_that_variable_is_or_does
-            :scores: torch.Tensor, shape [batch_size, n]
-                Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+        _Returns_
+          ~ predictions: torch.Tensor
+          ~     TODO.What_that_variable_is_or_does
+          ~ scores: torch.Tensor, shape [batch_size, n]
+          ~     Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         """
         with torch.no_grad():
@@ -187,14 +180,16 @@ class EdgeInference:
 
 
 class NodeInference:
-    """{py:class} NodeInference
-    
+    """
     Use trained embedding model to infer missing entities in triples.
 
-    :param kg: Knowledge graph on which the inference will be done.
-    :type kg: KnowledgeGraph
-    :return: Knowledge graph on which the inference will be done. TODO.should_be_attribute_not_return
-    :rtype: KnowledgeGraph
+    ## Arguments
+      ~ kg: KnowledgeGraph
+      ~     Knowledge graph on which the inference will be done.
+
+    ## __Attributes__
+      ~ kg: KnowledgeGraph
+      ~     Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -214,47 +209,39 @@ class NodeInference:
                 edge_embeddings: nn.Embedding,
                 verbose: bool = True,
                 **_):
-        """{py:function} evaluate(node_indices, priority, edge_indices, top_k, missing_triplet_part, batch_size, encoder, decoder, node_embeddings, edge_embeddings, verbose)}
-        
+        """
         Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
-        :param node_indices: The indices of nodes (from the knowledge graph).
-        :type node_indices: torch.Tensor
-        
-        :param edge_indices: The indices of edges (from the knowledge graph).
-        :type edge_indices: torch.Tensor
-        
-        :param top_k: Indicate the number of top predictions to return.
-        :type top_k: int, keyword-only
-        
-        :param missing_triplet_part: String indicating if the missing nodes are the heads or the tails.
-        :type missing_triplet_part: Literal["head", "tail"], keyword-only
-        
-        :param batch_size: Size of the current batch.
-        :type batch_size: int, keyword-only
-        
-        :param encoder: Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        :type encoder: DefaultEncoder or GNN, keyword-only
-        :param decoder: Decoder model to evaluate.
-        :type decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
-        
-        :param node_embeddings: A list containing all embeddings for each node type.
-                                keys: node type index
-                                values: tensors of shape (node_count, embedding_dimensions)
-        :type node_embeddings: nn.ParameterList, keyword-only
-        
-        :param edge_embeddings: A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-        
-        :type edge_embeddings: nn.Embedding, keyword-only
-        
-        :param verbose: Indicate whether a progress bar should be displayed during
-                        evaluation.
-        
-        :type verbose: bool, default to True, keyword-only
+        # Arguments
+          ~ node_indices: torch.Tensor
+          ~     The indices of nodes (from the knowledge graph).
+          ~ edge_indices: torch.Tensor
+          ~     The indices of edges (from the knowledge graph).
+          ~ top_k: int, keyword-only
+          ~     Indicate the number of top predictions to return.
+          ~ missing_triplet_part: Literal["head", "tail"], keyword-only
+          ~     String indicating if the missing nodes are the heads or the tails.
+          ~ batch_size: int, keyword-only
+          ~     Size of the current batch.
+          ~ encoder: DefaultEncoder or GNN, keyword-only
+          ~     Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+          ~ decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+          ~     Decoder model to evaluate.
+          ~ node_embeddings: nn.ParameterList, keyword-only
+          ~     A list containing all embeddings for each node type.
+          ~     keys: node type index
+          ~     values: tensors of shape (node_count, embedding_dimensions)
+          ~ edge_embeddings: nn.Embedding, keyword-only
+          ~     A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+          ~ verbose: bool, default to True, keyword-only
+          ~     Indicate whether a progress bar should be displayed during evaluation.
 
-        :returns: * **predictions** (*torch.Tensor*) -- TODO.What_that_variable_is_or_does
-                  * **scores** (*torch.Tensor, shape [batch_size, n]*) -- Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
-
+        ### Returns
+          ~ predictions: torch.Tensor
+          ~     TODO.What_that_variable_is_or_does
+          ~ scores: torch.Tensor, shape [batch_size, n]
+          ~     Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+        
         """
         with torch.no_grad():
             device = edge_embeddings.weight.device

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -17,35 +17,30 @@ from .utils import filter_scores
 
 class Inference_KG(Dataset):
     """
-    Subset of a KG used for inference.
-    
-    This class inherits from the PyTorch `utils.data.Dataset` class:
-    https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html
+    Placeholder
+      ~ Subset of a KG used for inference.
+      ~ This class inherits from the PyTorch `utils.data.Dataset` class:
+      ~ https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html
 
     Arguments
-    ---------
-    first_index_tensor: torch.Tensor
-        The first tensor with indices of the edges or nodes (from the knowledge graph).
-    second_index_tensor: torch.Tensor
-        The second tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ first_index_tensor: torch.Tensor
+      ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ second_index_tensor: torch.Tensor
+      ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
 
     Attributes
-    ----------
-    first_index_tensor: torch.Tensor
-        The first tensor with indices of the edges or nodes (from the knowledge graph).
-    second_index_tensor: torch.Tensor
-        The second tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ first_index_tensor: torch.Tensor
+      ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ second_index_tensor: torch.Tensor
+      ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
     
     Raises
-    ------
-    AssertionError
-        Both index tensors must be of the same size.
+      ~ AssertionError
+      ~     Both index tensors must be of the same size.
 
     Notes
-    -----
-    Either both tensors are nodes, or they are node and edge.
-    The `__getitem__` method allows to call an `Inference_KG` object with an index,
-    giving back a tuple containing the corresponding values of both tensors.
+      ~ Either both tensors are nodes, or they are node and edge.
+      ~ The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
     
     """
     def __init__(self,
@@ -69,15 +64,16 @@ class Inference_KG(Dataset):
 
 class EdgeInference:
     """
-    Use trained embedding model to infer missing edges in triplets.
+    Placeholder
+      ~ Use trained embedding model to infer missing edges in triplets.
 
-    :arg kg: Knowledge graph on which the inference will be done.
-    :type kg: KnowledgeGraph
+    Arguments
+      ~ Knowledge graph on which the inference will be done.
+      ~     KnowledgeGraph
 
     Attributes
-    ----------
-    kg: KnowledgeGraph
-        Knowledge graph on which the inference will be done.
+      ~ KnowledgeGraph
+      ~     Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -96,43 +92,43 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        TODO.What_the_function_does_about_globally
+        :Placeholder: TODO.What_the_function_does_about_globally
 
-        :type head_indices: torch.Tensor
-        :arg head_indices: The indices of the head nodes (from the knowledge graph).
-        
-        :type tail_indices: torch.Tensor
-        :arg tail_indices: The indices of the tail nodes (from the knowledge graph).
-        
-        :type top_k: int, keyword-only
-        :arg top_k: Indicate the number of top predictions to return.
-        
-        :type batch_size: int, keyword-only
-        :arg batch_size: Size of the current batch.
-        
-        :type encoder: DefaultEncoder or GNN, keyword-only
-        :arg encoder: Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        
-        :type decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
-        :arg decoder: Decoder model to evaluate.
-        
-        :type node_embeddings: nn.ParameterList, keyword-only
-        :arg node_embeddings: A list containing all embeddings for each node type.
-            keys: node type index
-            values: tensors of shape (node_count, embedding_dimensions)
-        
-        :type edge_embeddings: nn.Embedding, keyword-only
-        :arg A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-        
-        :type verbose: bool, default to True, keyword-only
-        :arg verbose: Indicate whether a progress bar should be displayed during evaluation.
+        :Arguments:
+            :head_indices: torch.Tensor
+                The indices of the head nodes (from the knowledge graph).
 
-        Returns
-        -------
-        :rtype predictions: torch.Tensor
-        :returns predictions: TODO.What_that_variable_is_or_does
-        :rtype scores: torch.Tensor, shape [batch_size, n]
-        :returns scores: Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+            :tail_indices: torch.Tensor
+                The indices of the tail nodes (from the knowledge graph).
+
+            :top_k: int, keyword-only
+                Indicate the number of top predictions to return.
+
+            :batch_size: int, keyword-only
+                Size of the current batch.
+
+            :encoder: DefaultEncoder or GNN, keyword-only
+                Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+
+            :decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+                Decoder model to evaluate.
+
+            :node_embeddings: nn.ParameterList, keyword-only
+                node_embeddings: A list containing all embeddings for each node type.
+                    keys: node type index
+                    values: tensors of shape (node_count, embedding_dimensions)
+
+            :edge_embeddings: nn.Embedding, keyword-only
+                A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+
+            :verbose: bool, default to True, keyword-only
+                Indicate whether a progress bar should be displayed during evaluation.
+
+        :Returns:
+            :predictions: torch.Tensor
+                TODO.What_that_variable_is_or_does
+            :scores: torch.Tensor, shape [batch_size, n]
+                Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         """
         with torch.no_grad():
@@ -191,18 +187,14 @@ class EdgeInference:
 
 
 class NodeInference:
-    """
+    """{py:class} NodeInference
+    
     Use trained embedding model to infer missing entities in triples.
 
-    Parameters
-    ----------
-    kg: KnowledgeGraph
-        Knowledge graph on which the inference will be done.
-    
-    Attributes
-    ----------
-    kg: KnowledgeGraph
-        Knowledge graph on which the inference will be done.
+    :param kg: Knowledge graph on which the inference will be done.
+    :type kg: KnowledgeGraph
+    :return: Knowledge graph on which the inference will be done. TODO.should_be_attribute_not_return
+    :rtype: KnowledgeGraph
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -222,7 +214,8 @@ class NodeInference:
                 edge_embeddings: nn.Embedding,
                 verbose: bool = True,
                 **_):
-        """
+        """{py:function} evaluate(node_indices, priority, edge_indices, top_k, missing_triplet_part, batch_size, encoder, decoder, node_embeddings, edge_embeddings, verbose)}
+        
         Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
         :param node_indices: The indices of nodes (from the knowledge graph).

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -132,7 +132,7 @@ class EdgeInference:
         <strong>Arguments</strong>
         </span>
 
-        **head_indices** *(torch.Tensor
+        **head_indices** *(torch.Tensor)*
         : The indices of the head nodes (from the knowledge graph).
         
         **tail_indices** *(torch.Tensor)*
@@ -147,7 +147,7 @@ class EdgeInference:
         **encoder** *(DefaultEncoder or GNN, keyword-only)*
         : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
         
-        **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+        **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder)*
         : Decoder model to evaluate.
         
         **node_embeddings** *(nn.ParameterList, keyword-only)*

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -17,37 +17,45 @@ from .utils import filter_scores
 
 class Inference_KG(Dataset):
     """
-    <span style="background-color:#06402B"> 
-    **Description**
+    <span style="color:#8B0000"> 
+    <strong>Description</strong>
     </span>
-      ~ Subset of a KG used for ==inference==.
-      ~ This class inherits from the PyTorch [`utils.data.Dataset`](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
-
-    **Arguments**
-      ~ **first_index_tensor:** torch.Tensor
-           The first tensor with indices of the edges or nodes (from the knowledge graph).
-      ~ **second_index_tensor:** torch.Tensor
-           <span style="background-color:#06402B"> 
-           The second tensor with indices of the edges or nodes (from the knowledge graph).
-           </span>
-
-    **Attributes**
-      ~ **first_index_tensor:** torch.Tensor
-          The first tensor with indices of the edges or nodes (from the knowledge graph).
-      ~ **second_index_tensor:** torch.Tensor
-           The second tensor with indices of the edges or nodes (from the knowledge graph).
     
-    <span style="color:red">
-    **Raises**
-    </span>
-      ~ **AssertionError**
-           Both index tensors must be of the same size.
+    Subset of a KG used for ==inference==.
+    
+    This class inherits from the PyTorch [`utils.data.Dataset`](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
 
-    **Notes**
-      ~ Either both tensors are nodes, or they are node and edge.
-      <span style="color:red">
-      ~ The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
-      </span>
+    <span style="color:#8B0000"> 
+    <strong>Arguments</strong>
+    </span>
+    
+      : **first_index_tensor:** torch.Tensor
+      : >    The first tensor with indices of the edges or nodes (from the knowledge graph).
+      : **second_index_tensor:** torch.Tensor
+      : >    The second tensor with indices of the edges or nodes (from the knowledge graph).
+
+    <span style="color:#8B0000"> 
+    <strong>Attributes</strong>
+    </span>
+    
+    : **first_index_tensor:** torch.Tensor
+    : >    The first tensor with indices of the edges or nodes (from the knowledge graph).
+    : **second_index_tensor:** torch.Tensor
+    : >    The second tensor with indices of the edges or nodes (from the knowledge graph).
+    
+    <span style="color:#8B0000"> 
+    <strong>Raises</strong>
+    </span>
+    
+    : **AssertionError**
+    : >    Both index tensors must be of the same size.
+
+    <span style="color:#8B0000"> 
+    <strong>Notes</strong>
+    </span>
+    
+    : Either both tensors are nodes, or they are node and edge.   
+    : The `__getitem__` method allows to call an `Inference_KG` object with an index, giving back a tuple containing the corresponding values of both tensors.
     
     """
     def __init__(self,
@@ -71,14 +79,23 @@ class Inference_KG(Dataset):
 
 class EdgeInference:
     """
-    **Description**
-    - Use trained embedding model to infer missing edges in triplets.
+    <span style="color:#8B0000"> 
+    <strong>Description</strong>
+    </span>
+    
+    Use trained embedding model to infer missing edges in triplets.
 
-    **Arguments**
+    <span style="color:#8B0000"> 
+    <strong>Arguments</strong>
+    </span>
+    
     - **kg:** KnowledgeGraph
          Knowledge graph on which the inference will be done.
 
-    **Attributes**
+    <span style="color:#8B0000"> 
+    <strong>Attributes</strong>
+    </span>
+    
     - **kg:** KnowledgeGraph
         →  Knowledge graph on which the inference will be done.
 
@@ -99,10 +116,17 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        **Description**
-          : TODO.What_the_function_does_about_globally
+        <span style="color:#8B0000"> 
+        <strong>Description</strong>
+        </span>
 
-        **Arguments**
+        *Missing documentation*
+        % TODO.What_the_function_does_about_globally
+
+        <span style="color:#8B0000"> 
+        <strong>Arguments</strong>
+        </span>
+
           : **head_indices:** torch.Tensor
               The indices of the head nodes (from the knowledge graph).
           : **tail_indices:** torch.Tensor
@@ -124,10 +148,14 @@ class EdgeInference:
           : **verbose:** bool, default to True, keyword-only
               Indicate whether a progress bar should be displayed during evaluation.
 
-        **Returns**
-          : **predictions:** torch.Tensor
-              TODO.What_that_variable_is_or_does
-          : **scores:** torch.Tensor, shape [batch_size, n]
+        <span style="color:#8B0000"> 
+        <strong>Returns</strong>
+        </span>
+
+          : **predictions** *(torch.Tensor)*
+              % TODO.What_that_variable_is_or_does
+              *Missing documentation*
+          : **scores** *(torch.Tensor, shape [batch_size, n])*
               Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         ---
@@ -190,15 +218,23 @@ class EdgeInference:
 
 class NodeInference:
     """
-    **Description**
+    <span style="color:#8B0000"> 
+    <strong>Description</strong>
+    </span>
     
     Use trained embedding model to infer missing nodes in triplets.
 
-    **Arguments**
+    <span style="color:#8B0000"> 
+    <strong>Arguments</strong>
+    </span>
+    
       ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
-    ***Attributes***
+    <span style="color:#8B0000"> 
+    <strong>Attributes</strong>
+    </span>
+    
       ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
@@ -221,10 +257,16 @@ class NodeInference:
                 verbose: bool = True,
                 **_):
         """
-        **Description**
+        <span style="color:#8B0000"> 
+        <strong>Description</strong>
+        </span>
+    
           : Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
-        **Arguments**
+        <span style="color:#8B0000"> 
+        <strong>Arguments</strong>
+        </span>
+        
           : **node_indices:** torch.Tensor
           : >    The indices of nodes (from the knowledge graph).
           : **edge_indices:** torch.Tensor
@@ -249,7 +291,10 @@ class NodeInference:
           : **verbose:** bool, default to True, keyword-only
           : >    Indicate whether a progress bar should be displayed during evaluation.
 
-        **Returns**
+        <span style="color:#8B0000"> 
+        <strong>Returns</strong>
+        </span>
+        
           : **predictions:** torch.Tensor
           :   >  TODO.What_that_variable_is_or_does
           : **scores:** torch.Tensor, shape [batch_size, n]

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -17,25 +17,25 @@ from .utils import filter_scores
 
 class Inference_KG(Dataset):
     """
-    **Placeholder**
+    ## Interface Class for Inference
       ~ Subset of a KG used for inference.
-      ~ This class inherits from the PyTorch [utils.data.Dataset](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
+      ~ This class inherits from the PyTorch [`utils.data.Dataset`](https://docs.pytorch.org/tutorials/beginner/basics/data_tutorial.html)
 
     **Arguments**
-      ~ first_index_tensor: torch.Tensor
-      ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
-      ~ second_index_tensor: torch.Tensor
-      ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ **first_index_tensor:** torch.Tensor
+           The first tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ **second_index_tensor:** torch.Tensor
+           The second tensor with indices of the edges or nodes (from the knowledge graph).
 
     **Attributes**
-      ~ first_index_tensor: torch.Tensor
-      ~     The first tensor with indices of the edges or nodes (from the knowledge graph).
-      ~ second_index_tensor: torch.Tensor
-      ~     The second tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ **first_index_tensor:** torch.Tensor
+          The first tensor with indices of the edges or nodes (from the knowledge graph).
+      ~ **second_index_tensor:** torch.Tensor
+           The second tensor with indices of the edges or nodes (from the knowledge graph).
     
     **Raises**
-      ~ AssertionError
-      ~     Both index tensors must be of the same size.
+      ~ **AssertionError**
+           Both index tensors must be of the same size.
 
     **Notes**
       ~ Either both tensors are nodes, or they are node and edge.
@@ -63,16 +63,16 @@ class Inference_KG(Dataset):
 
 class EdgeInference:
     """
-    **Placeholder**
-      ~ Use trained embedding model to infer missing edges in triplets.
+    ## Edge Inference Class
+    - Use trained embedding model to infer missing edges in triplets.
 
     **Arguments**
-      ~ kg: KnowledgeGraph
-      ~     Knowledge graph on which the inference will be done.
+    - **kg:** KnowledgeGraph
+         Knowledge graph on which the inference will be done.
 
     **Attributes**
-      ~ kg: KnowledgeGraph
-      ~     Knowledge graph on which the inference will be done.
+    - **kg:** KnowledgeGraph
+        →  Knowledge graph on which the inference will be done.
 
     """
     def __init__(self, kg: KnowledgeGraph):
@@ -91,37 +91,36 @@ class EdgeInference:
                 verbose: bool = True,
                 **_):
         """
-        **Placeholder**
-          ~ TODO.What_the_function_does_about_globally
+        ### Edge Inference `evaluate` Function
+          : TODO.What_the_function_does_about_globally
 
         **Arguments**
-          ~ head_indices: torch.Tensor
-          ~     The indices of the head nodes (from the knowledge graph).
-
-          ~ tail_indices: torch.Tensor
-          ~     The indices of the tail nodes (from the knowledge graph).
-          ~ top_k: int, keyword-only
-          ~     Indicate the number of top predictions to return.
-          ~ batch_size: int, keyword-only
-          ~     Size of the current batch.
-          ~ encoder: DefaultEncoder or GNN, keyword-only
-          ~     Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-          ~ decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
-          ~     Decoder model to evaluate.
-          ~ node_embeddings: nn.ParameterList, keyword-only
-          ~     A list containing all embeddings for each node type.
-          ~         keys: node type index
-          ~         values: tensors of shape (node_count, embedding_dimensions)
-          ~ edge_embeddings: nn.Embedding, keyword-only
-          ~     A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-          ~ verbose: bool, default to True, keyword-only
-          ~     Indicate whether a progress bar should be displayed during evaluation.
+          : **head_indices:** torch.Tensor
+              The indices of the head nodes (from the knowledge graph).
+          : **tail_indices:** torch.Tensor
+              The indices of the tail nodes (from the knowledge graph).
+          : **top_k:** int, keyword-only
+              Indicate the number of top predictions to return.
+          : **batch_size:** int, keyword-only
+              Size of the current batch.
+          : **encoder:** DefaultEncoder or GNN, keyword-only
+              Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+          : **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
+              Decoder model to evaluate.
+          : **node_embeddings:** nn.ParameterList, keyword-only
+              A list containing all embeddings for each node type.
+                  keys: node type index
+                  values: tensors of shape (node_count, embedding_dimensions)
+          : ** edge_embeddings:** nn.Embedding, keyword-only
+              A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+          : **verbose:** bool, default to True, keyword-only
+              Indicate whether a progress bar should be displayed during evaluation.
 
         **Returns**
-          ~ predictions: torch.Tensor
-          ~     TODO.What_that_variable_is_or_does
-          ~ scores: torch.Tensor, shape [batch_size, n]
-          ~     Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+          : **predictions:** torch.Tensor
+              TODO.What_that_variable_is_or_does
+          : **scores:** torch.Tensor, shape [batch_size, n]
+              Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
             
         """
         with torch.no_grad():
@@ -181,14 +180,15 @@ class EdgeInference:
 
 class NodeInference:
     """
-      ~ Use trained embedding model to infer missing entities in triples.
+    ## Node Inference Class
+      ~ Use trained embedding model to infer missing nodes in triplets.
 
     **Arguments**
-      ~ kg: KnowledgeGraph
+      ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
     **Attributes**
-      ~ kg: KnowledgeGraph
+      ~ **kg:** KnowledgeGraph
       ~     Knowledge graph on which the inference will be done.
 
     """
@@ -210,38 +210,38 @@ class NodeInference:
                 verbose: bool = True,
                 **_):
         """
-        **plop**
-          ~ Predict the missing node of a triplet where either head and edge or edge and tail are known.
+        ### Node Inference `evaluate` Function
+          : Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
         **Arguments**
-          ~ node_indices: torch.Tensor
-          ~     The indices of nodes (from the knowledge graph).
-          ~ edge_indices: torch.Tensor
-          ~     The indices of edges (from the knowledge graph).
-          ~ top_k: int, keyword-only
-          ~     Indicate the number of top predictions to return.
-          ~ missing_triplet_part: Literal["head", "tail"], keyword-only
-          ~     String indicating if the missing nodes are the heads or the tails.
-          ~ batch_size: int, keyword-only
-          ~     Size of the current batch.
-          ~ encoder: DefaultEncoder or GNN, keyword-only
-          ~     Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-          ~ decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
-          ~     Decoder model to evaluate.
-          ~ node_embeddings: nn.ParameterList, keyword-only
-          ~     A list containing all embeddings for each node type.
-          ~     keys: node type index
-          ~     values: tensors of shape (node_count, embedding_dimensions)
-          ~ edge_embeddings: nn.Embedding, keyword-only
-          ~     A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-          ~ verbose: bool, default to True, keyword-only
-          ~     Indicate whether a progress bar should be displayed during evaluation.
+          : **node_indices:** torch.Tensor
+          : >    The indices of nodes (from the knowledge graph).
+          : **edge_indices:** torch.Tensor
+          : >    The indices of edges (from the knowledge graph).
+          : **top_k:** int, keyword-only
+          : >    Indicate the number of top predictions to return.
+          : **missing_triplet_part:** Literal["head", "tail"], keyword-only
+          : >    String indicating if the missing nodes are the heads or the tails.
+          : **batch_size:** int, keyword-only
+          : >    Size of the current batch.
+          : **encoder:** DefaultEncoder or GNN, keyword-only
+          : >    Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+          : **decoder:** BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+          : >    Decoder model to evaluate.
+          : **node_embeddings:** nn.ParameterList, keyword-only
+          : >    A list containing all embeddings for each node type.
+          : >    keys: node type index
+          : >    values: tensors of shape (node_count, embedding_dimensions)
+          : **edge_embeddings:** nn.Embedding, keyword-only
+          : >    A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+          : **verbose:** bool, default to True, keyword-only
+          : >    Indicate whether a progress bar should be displayed during evaluation.
 
         **Returns**
-          ~ predictions: torch.Tensor
-          ~     TODO.What_that_variable_is_or_does
-          ~ scores: torch.Tensor, shape [batch_size, n]
-          ~     Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+          : **predictions:** torch.Tensor
+          :   >  TODO.What_that_variable_is_or_does
+          : **scores:** torch.Tensor, shape [batch_size, n]
+          :   >  Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
         
         """
         with torch.no_grad():

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -194,8 +194,8 @@ class NodeInference:
     """
     Use trained embedding model to infer missing entities in triples.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     kg: KnowledgeGraph
         Knowledge graph on which the inference will be done.
     
@@ -225,39 +225,43 @@ class NodeInference:
         """
         Predict the missing node of a triplet where either head and edge or edge and tail are known.
 
-        Arguments
-        ---------
-        node_indices: torch.Tensor
-            The indices of nodes (from the knowledge graph).
-        edge_indices: torch.Tensor
-            The indices of edges (from the knowledge graph).
-        top_k: int, keyword-only
-            Indicate the number of top predictions to return.
-        missing_triplet_part: Literal["head", "tail"], keyword-only
-            String indicating if the missing nodes are the heads or the tails.
-        batch_size: int, keyword-only
-            Size of the current batch.
-        encoder: DefaultEncoder or GNN, keyword-only
-            Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
-            Decoder model to evaluate.
-        node_embeddings: nn.ParameterList, keyword-only
-            A list containing all embeddings for each node type.
-            keys: node type index
-            values: tensors of shape (node_count, embedding_dimensions)
-        edge_embeddings: nn.Embedding, keyword-only
-            A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
-        verbose: bool, default to True, keyword-only
-            Indicate whether a progress bar should be displayed during
-            evaluation.
+        :param node_indices: The indices of nodes (from the knowledge graph).
+        :type node_indices: torch.Tensor
+        
+        :param edge_indices: The indices of edges (from the knowledge graph).
+        :type edge_indices: torch.Tensor
+        
+        :param top_k: Indicate the number of top predictions to return.
+        :type top_k: int, keyword-only
+        
+        :param missing_triplet_part: String indicating if the missing nodes are the heads or the tails.
+        :type missing_triplet_part: Literal["head", "tail"], keyword-only
+        
+        :param batch_size: Size of the current batch.
+        :type batch_size: int, keyword-only
+        
+        :param encoder: Encoder model to embed the nodes. Deactivated with DefaultEncoder.
+        :type encoder: DefaultEncoder or GNN, keyword-only
+        :param decoder: Decoder model to evaluate.
+        :type decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only
+        
+        :param node_embeddings: A list containing all embeddings for each node type.
+                                keys: node type index
+                                values: tensors of shape (node_count, embedding_dimensions)
+        :type node_embeddings: nn.ParameterList, keyword-only
+        
+        :param edge_embeddings: A tensor containing one embedding by edge type, of shape (edge_count, embedding_dimensions).
+        
+        :type edge_embeddings: nn.Embedding, keyword-only
+        
+        :param verbose: Indicate whether a progress bar should be displayed during
+                        evaluation.
+        
+        :type verbose: bool, default to True, keyword-only
 
-        Returns
-        -------
-        predictions: torch.Tensor
-            TODO.What_that_variable_is_or_does
-        scores: torch.Tensor, shape [batch_size, n]
-            Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
-            
+        :returns: * **predictions** (*torch.Tensor*) -- TODO.What_that_variable_is_or_does
+                  * **scores** (*torch.Tensor, shape [batch_size, n]*) -- Tensor with -Inf values for all true nodes/edges indices except the ones being predicted.
+
         """
         with torch.no_grad():
             device = edge_embeddings.weight.device


### PR DESCRIPTION
## What are the changes for using KGATE?
The ReadTheDoc (RTD) web page wille now properly include the docstrings automatically.

For now it only affects the Inference page, which got added, but it should be extended to all documented files.

## Why am I making these changes?
The `autodoc` plugin was already used for this objective, but did not work with MyST because of incompatibility with MyST.

## What are the changes from a developer perspective?
- `index.md`: now includes inference
- `conf.py`: changes in packages
  - removed Sphinx `autodoc` package
  - added `autodoc2` package and required associated calls
  - added `fieldlist` MyST extension
- `inference.py`: updated docstrings formatting to display properly on the RTD page thanks to markdown syntax
- `inference.md`: created, with titles properly formatted and functioning docstring calls.

## How to test the changes?
In an adapted environment, `make html` in the doc folder, then go to `file:///your_path/html/inference.html` to see the updated RTD page.

## Checklist
- [x] **I'm using `doc` as my base branch**
- [x] There is no overlap with another PR
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com//BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I maintained consistency with the project's text
  - [x] All comments are in American English
- [x] I have tested the changes manually