### PR TITLE
[Github] Fix git templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,19 +6,21 @@
 Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
 Ideally the title is less than or equal to 72 characters (GitHub cuts off commit titles longer than this length).
 
-TODO, rework/add: See https://github.com/BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request
+See https://github.com/BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request
 for more information on the allowed scopes and prefixes.
 
 Example:
-implements(decoder): SpherE complete implementation
-^           ^        ^
-|           |        |__ Subject
-|           |___________ Scope (optional)
-|_______________________ Prefix
+[Feat] (decoder) SpherE complete implementation
+^      ^         ^
+|      |         |__ Subject
+|      |____________ Scope (optional)
+|___________________ Prefix
+
 -->
 
 <!--
 Make sure that this PR is not overlapping with someone else's work.
+
 Please try to keep the PR self-contained (don't change a bunch of unrelated things).
 -->
 
@@ -28,7 +30,7 @@ The second and third section are mandatory.
 -->
 
 <!--
-This PR template was inspired by https://github.com/pagefaultgames/pokerogue
+This PR template was inspired by the one of https://github.com/pagefaultgames/pokerogue
 -->
 
 ## What are the changes for using KGATE?
@@ -56,7 +58,7 @@ Ex: What files have been changed? What classes/functions/variables/etc have been
 ## How to test the changes?
 <!--
 How can a reviewer test your changes once they check out on your branch?
-TODO, rework/add: Did you make use of the `utils.py` file?
+Did you make use of the `utils.py` file?
 Did you introduce any automated tests?
 Do the reviewers need to do something special in order to test your changes?
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ All changes must be thoroughly documented in the appropriate docstrings, and in 
 TODO, add: when we have a test folder and suite
 
 A great way to develop an understanding of how the project works is to look at test cases (located in [the `test` folder](./tests/)).
-Tests show you both how things are supposed to work.
+Tests show you how things are supposed to work.
 -->
 
 
@@ -120,7 +120,6 @@ Most information related to submitting a pull request is contained in comments w
 however full documentation on the pull request title format is here to best utilize the space available.
 
 The pull request title must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format with a valid prefix and optionally a valid scope. \
-If a save migrator, version increase or other breaking change is part of the PR, a `!` must be added before the `:`.
 
 Try to keep the PR title to 72 characters or less (GitHub cuts off commit titles longer than this).
 
@@ -143,7 +142,7 @@ Try to keep the PR title to 72 characters or less (GitHub cuts off commit titles
 - "Chore" - Misc project upkeep (e.g. updating submodules, updating dependencies, reverting a bad commit) not covered by other prefixes
 - "Dev" - Improving the developer experience (such as by modifying lint rules or creating cli scripts)
 - "Docs" - Primarily adding/updating documentation
-- "feat" - Adding a new feature (e.g. adding a new implementation of a decoder) or redesigning an existing feature
+- "Feat" - Adding a new feature (e.g. adding a new implementation of a decoder) or redesigning an existing feature
 - "Fix" - Fixing a bug
 - "Github" - Updating the CI pipeline or otherwise modifying something in the `./github/**` directory
 - "Misc" - A change that doesn't fit any other prefix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,10 +116,9 @@ Most non-trivial changes (*especially bug fixes*) should come along with new tes
 
 ## ✅ Submitting a Pull Request
 
-Most information related to submitting a pull request is contained in comments within the pull request template that is shown when you open a new pull request,
-however full documentation on the pull request title format is here to best utilize the space available.
+Most information related to submitting a pull request is contained in comments within the pull request template that is shown when you open a new pull request, however full documentation on the pull request title format is here to best utilize the space available.
 
-The pull request title must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format with a valid prefix and optionally a valid scope. \
+The pull request title must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format with a valid prefix and optionally a valid scope.
 
 Try to keep the PR title to 72 characters or less (GitHub cuts off commit titles longer than this).
 


### PR DESCRIPTION
## What are the changes for using KGATE?
None.

## Why am I making these changes?
There were inconsistencies in git templates.

## What are the changes from a developer perspective?
- `CONTRIBUTING.md`:
  - removed irrelevant mentions
  - fixed typos
- `pull_request_template.md`
  - PR name example now consistent with the one in `CONTRIBUTING.md`

## How to test the changes?
Read on GitHub.

## Checklist
- [x] **I'm using `dev` as my base branch**
- [x] There is no overlap with another PR
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com//BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I maintained consistency with the project's text
  - [x] Variables have consistent names
  - [x] All comments are in American English
- [x] I have tested the changes manually