### PR TITLE
Refactor (initialization): Refactoring of embedding initialization into a dedicated class

### DIFF
--- a/src/kgate/__init__.py
+++ b/src/kgate/__init__.py
@@ -1,5 +1,6 @@
 from .knowledgegraph import KnowledgeGraph
 from .architect import Architect
-from .utils import initialize_embedding, read_train_metrics
+from .utils import read_train_metrics
 from .grid_search import run_grid_search
 from .evaluators import LinkPredictionEvaluator, TripletClassificationEvaluator
+from .initializers import Initializer

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -1044,14 +1044,18 @@ class Architect(Module):
 
         target_edges_result = {}
 
-        all_edges: Set[Any] = set(self.kg_test.edge_to_index.keys())
+        all_edges: Set[Any] = set(self.knowledge_graph.edge_to_index.keys())
         remaining_edges = all_edges - set(target_edges)
         remaining_edges = list(remaining_edges)
         
         triplet_count_target_edges = 0
+        test_knowledge_graph = Subset(self.knowledge_graph, self.knowledge_graph.test_mask.nonzero(as_tuple = True)[0])
+        
+        metrics_sum_target_edges = 0.0
+        triplet_count_target_edges = 0
 
         if len(remaining_edges) != len(all_edges):
-            metrics_sum_target_edges, triplet_count_target_edges, individual_metrics_target_edges, group_metrics_target_edges = self.calculate_metrics_for_edges(self.kg_test, target_edges)
+            metrics_sum_target_edges, triplet_count_target_edges, individual_metrics_target_edges, group_metrics_target_edges = self.calculate_metrics_for_edges(test_knowledge_graph, target_edges)
             
             target_edges_result = {
                 "target_edges": {
@@ -1060,7 +1064,7 @@ class Architect(Module):
                 },
             }
 
-        total_metrics_sum_remaining, triplet_count_remaining, individual_metrics_remaining, group_metrics_remaining = self.calculate_metrics_for_edges(self.kg_test, remaining_edges)
+        total_metrics_sum_remaining, triplet_count_remaining, individual_metrics_remaining, group_metrics_remaining = self.calculate_metrics_for_edges(test_knowledge_graph, remaining_edges)
 
         global_metrics = (metrics_sum_target_edges + total_metrics_sum_remaining) / (triplet_count_target_edges + triplet_count_remaining)
 
@@ -1643,8 +1647,6 @@ class Architect(Module):
             if indices_to_keep.numel() == 0:
                 continue  # Skip to next edge if no triplet found
             
-            edge_subset = graphindices[:, indices_to_keep]
-
             if isinstance(self.evaluator, LinkPredictionEvaluator):
                 test_metrics = self.link_prediction(Subset(knowledge_graph, indices_to_keep))
             elif isinstance(self.evaluator, TripletClassificationEvaluator):
@@ -1685,8 +1687,8 @@ class Architect(Module):
         
         """
         # Create subgraph for frequent and infrequent categories
-        kg_frequent = self.kg_test.remove_triplets_from_training(~frequent_indices)
-        kg_infrequent = self.kg_test.remove_triplets_from_training(~infrequent_indices)
+        kg_frequent = self.knowledge_graph.remove_triplets_from_training(~frequent_indices)
+        kg_infrequent = self.knowledge_graph.remove_triplets_from_training(~infrequent_indices)
         
         # Compute each category's MRR
         if isinstance(self.evaluator, LinkPredictionEvaluator):

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -2,6 +2,10 @@
 Architect class and methods to run a KGE model training, testing and inference from end to end.
 """
 
+from kgate.initializers import Node2VecInitializer
+from torch_geometric.nn import Node2Vec
+from kgate.initializers import FeatureInitializer
+from kgate import Initializer
 import csv
 import gc
 import logging
@@ -13,7 +17,7 @@ from collections.abc import Callable
 from glob import glob
 from inspect import signature
 from pathlib import Path
-from typing import Tuple, Dict, List, Any, Set, Literal, Optional
+from typing import Tuple, Dict, List, Any, Set, Literal
 from collections.abc import Callable
 
 import pandas as pd
@@ -21,15 +25,11 @@ import numpy as np
 import tomli_w
 
 from torchkge import KnowledgeGraph
-from torchkge.models import Model
-import torchkge.sampling as sampling
 from torchkge.utils import MarginLoss, BinaryCrossEntropyLoss
-
-from torch_geometric.utils import k_hop_subgraph
 
 import torch
 from torch import tensor, Tensor
-from torch.nn import Parameter, Module
+from torch.nn import Module
 import torch.optim as optim
 
 from torch.utils.data import DataLoader, Subset
@@ -38,11 +38,11 @@ from ignite.engine import Events, Engine
 from ignite.handlers import EarlyStopping, ModelCheckpoint, Checkpoint, DiskSaver, ProgressBar
 from ignite.metrics import RunningAverage
 
-from torch_geometric.utils import k_hop_subgraph
 
 from torchkge.utils import MarginLoss, BinaryCrossEntropyLoss
 
 from .data_leakage import permute_tails
+from .initializers import *
 from .decoders import *
 from .encoders import *
 from .evaluators import LinkPredictionEvaluator, TripletClassificationEvaluator
@@ -50,7 +50,7 @@ from .inference import NodeInference, EdgeInference
 from .knowledgegraph import KnowledgeGraph
 from .preprocessing import prepare_knowledge_graph, SUPPORTED_SEPARATORS
 from .samplers import NegativeSampler, PositionalNegativeSampler, BernoulliNegativeSampler, UniformNegativeSampler, MixedNegativeSampler
-from .utils import parse_config, load_knowledge_graph, set_random_seeds, find_best_model, merge_kg, initialize_embedding, plot_learning_curves, save_config
+from .utils import parse_config, load_knowledge_graph, set_random_seeds, find_best_model, merge_kg, plot_learning_curves, save_config
 
 
 # Configure logging
@@ -109,7 +109,7 @@ class Architect(Module):
         values: tensors of shape [node_count, node_embedding_dimensions]
     edge_embeddings: nn.Embedding, shape: [edge_type_count, edge_embedding_dimensions]
         Embeddings for each edge type.
-    encoder: DefaultEncoder or GNN
+    encoder: GNN or None
         Encoder model of the autoencoder.
         For more details, refer to the `initialize_encoder` function.
     decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
@@ -242,7 +242,8 @@ class Architect(Module):
                 self.knowledge_graph = knowledge_graph
 
         # Initialize attributes
-        self.encoder: DefaultEncoder | GNN = None
+        self.initializer: Initializer = None
+        self.encoder: GNN | None = None
         self.decoder: BilinearDecoder | ConvolutionalDecoder | TranslationalDecoder = None
         self.decoder_loss: MarginLoss | BinaryCrossEntropyLoss = None
         self.skip_normalization: bool = False
@@ -362,12 +363,12 @@ class Architect(Module):
     def initialize_encoder( self,
                             encoder_name: Literal["Default", "GCN", "GAT", "Node2Vec", ""] = "",
                             gnn_layers: int = 0
-                            ) -> DefaultEncoder | GCNEncoder | GATEncoder:
+                            ) -> GCNEncoder | GATEncoder | None:
         """
         Create and initialize the encoder object according to the configuration or arguments.
 
         The encoder is created from PyG encoding layers. Currently, the implemented encoders 
-        are a random initialization, **GCN** [1]_, **GAT** [2]_ and **Node2Vec** [3]_. See the encoder class for a detailed
+        are a random initialization, **GCN** [1]_, **GAT** [2]_. See the encoder class for a detailed
         explanation of the encoders.
 
         If both configuration and arguments are given, the arguments take priority.
@@ -377,7 +378,6 @@ class Architect(Module):
         TODO: proper links to the references
         .. [1] Kipf, Thomas and Max Welling. “Semi-Supervised Classification with Graph Convolutional Networks.” ArXiv abs/1609.02907 (2016): n. pag.
         .. [2] Brody, Shaked et al. “How Attentive are Graph Attention Networks?” ArXiv abs/2105.14491 (2021): n. pag.
-        .. [3] TODO: add reference to Node2Vec
 
         Arguments
         ---------
@@ -392,8 +392,8 @@ class Architect(Module):
 
         Returns
         -------
-        encoder: DefaultEncoder or GCNEncoder or GATEncoder or Node2VecEncoder
-            The encoder object.
+        encoder: GCNEncoder or GATEncoder or None
+            The encoder object, or None if there is no encoder.
         
         """
         encoder_config: dict = self.config["model"]["encoder"]
@@ -406,16 +406,14 @@ class Architect(Module):
         edge_types = self.knowledge_graph.triplet_types
 
         match encoder_name:
-            case "Default":
-                encoder = DefaultEncoder()
+            case "None":
+                encoder = None
             case "GCN": 
                 encoder = GCNEncoder(edge_types, self.encoder_node_embedding_dimensions, gnn_layers)
             case "GAT":
                 encoder = GATEncoder(edge_types, self.encoder_node_embedding_dimensions, gnn_layers)
-            case "Node2Vec":
-                encoder = Node2VecEncoder(self.knowledge_graph.edge_list[:, self.knowledge_graph.train_mask], self.encoder_node_embedding_dimensions, device = self.device, **encoder_config["params"])
             case _:
-                encoder = DefaultEncoder()
+                encoder = None
                 logging.warning(f"Unrecognized encoder {encoder_name}. Defaulting to a random initialization.")
         
         return encoder
@@ -727,6 +725,31 @@ class Architect(Module):
         
         return evaluator
     
+    def initialize_initializer(self) -> Initializer:
+        """
+        Set the method used to generate initial embeddings
+        
+        Options are random initialization, which is equivalent to just a lookup embedding,
+        user-supplied features that can be learnt with a deep encoder, and Node2Vec."""
+        match self.config["initializer"]["name"]:
+            case "Random":
+                initializer = Initializer()
+            case "Feature":
+                initializer = FeatureInitializer() #TODO
+            case "Node2Vec":
+                initializer = Node2VecInitializer(
+                    edge_indices = self.knowledge_graph.edge_list[:, self.knowledge_graph.train_mask],
+                    embedding_dimensions = self.node_embedding_dimensions,
+                    walk_length = self.config["initializer"]["walk_length"],
+                    context_size = self.config["initializer"]["context_size"],
+                    output_directory = self.checkpoints_directory,
+                    device = self.device
+                )
+            case _:
+                raise NotImplementedError(f"The requested initializer {self.config["initializer"]["name"]} is not implemented.")
+            
+        logging.info(f"Using the {self.config["initializer"]["name"]} initializer")
+        return initializer
 
     def initialize_model(self,
                         attributes: Dict[str, pd.DataFrame] = {},
@@ -775,47 +798,23 @@ class Architect(Module):
         self.encoder = self.encoder or self.initialize_encoder()
 
         logging.info("Initializing embeddings...")
-        
+        self.initializer = self.initializer or self.initialize_initializer()
+
         # If given a pretrained embedding file (such as the output of a Node2Vec), we use that in priority
         if pretrained is not None and pretrained.exists():
             self.knowledge_graph.node_embeddings = torch.load(pretrained)
         else:
-            assert isinstance(self.encoder, GNN) or len(self.knowledge_graph.node_type_to_index) == 1, "When not using a GNN as encoder, the node_type shouldn't be supplied."
+            self.initializer.initialize_all_embeddings(self.knowledge_graph,
+                                                        node_embedding_dimensions = self.node_embedding_dimensions,
+                                                        edge_embedding_dimensions = self.edge_embedding_dimensions,
+                                                        device = self.device,
+                                                        inplace = True)
 
-            # create initial embeddings
-            node_embeddings = nn.ParameterList()
-            index_to_node_type = {value: key for key,value in self.knowledge_graph.node_type_to_index.items()}
-            for node_type in self.knowledge_graph.node_type_to_global:
-                node_count = self.knowledge_graph.node_type_to_global[node_type].size(0)
-                if node_type in attributes:
-                    # if feature attributes given, initialization based on them
-                    current_attribute: pd.DataFrame = attributes[node_type]
-                    assert current_attribute.shape[0] == node_count, f"The length of the given attribute ({len(current_attribute)}) must match the number of nodes of this type ({node_count})."
-                    input_features = torch.zeros((node_count,current_attribute.shape[1]), dtype = torch.float)
-                    for node in current_attribute.index:
-                        node_index = self.knowledge_graph.node_to_index[node]
-                        node_type_index = self.knowledge_graph.node_types[node_index]
-                        local_index = self.knowledge_graph.global_to_local_indices[node_index]
-                        assert node_type_index == self.knowledge_graph.node_type_to_index[node_type], f"The node {node} is given as {node_type} but registered as {index_to_node_type[str(node_type_index)]} in the KG."
-
-                        input_features[local_index] = tensor(current_attribute.loc[node], dtype = torch.float)
-                    
-                    node_embeddings.append(Parameter(input_features).to(self.device))
-                    
-                else:
-                    # if no feature attribute given, random initialization
-                    node_embedding_dimensions = self.node_embedding_dimensions if isinstance(self.encoder, GNN) else self.encoder_node_embedding_dimensions
-                    embeddings = initialize_embedding(node_count, node_embedding_dimensions, self.device)
-                    node_embeddings.append(embeddings.weight)
-
-            self.knowledge_graph.node_embeddings = node_embeddings
-
-            if isinstance(self.encoder, GNN):     
+            if self.encoder is not None:     
                 # The input features are not supposed to change if we use an encoder
                 # TODO: make it an hyperparameter
                 self.knowledge_graph.node_embeddings.requires_grad_(False)
 
-        self.knowledge_graph.edge_embeddings = initialize_embedding(self.knowledge_graph.edge_count, self.encoder_edge_embedding_dimensions, self.device).weight
 
         logging.info("Initializing optimizer...")
         self.optimizer = self.optimizer or self.initialize_optimizer()
@@ -933,7 +932,7 @@ class Architect(Module):
             "trainer": trainer,
         }
 
-        if isinstance(self.encoder, GNN):
+        if self.encoder is not None:
             to_save.update({"encoder": self.encoder})
         if self.scheduler is not None:
             to_save.update({"scheduler": self.scheduler})
@@ -958,7 +957,7 @@ class Architect(Module):
 
             """
             # Move models to CPU before saving
-            if isinstance(self.encoder, GNN):
+            if self.encoder is not None:
                 self.encoder.to("cpu")
             self.decoder.to("cpu")
             self.knowledge_graph.embeddings.to("cpu")
@@ -967,7 +966,7 @@ class Architect(Module):
             checkpoint_handler(engine)
 
             # Move models back to GPU
-            if isinstance(self.encoder, GNN):
+            if self.encoder is not None:
                 self.encoder.to(self.device)
             self.decoder.to(self.device)
             self.knowledge_graph.embeddings.to(self.device)
@@ -1202,7 +1201,7 @@ class Architect(Module):
         # Check node and edge dictionnary size
         assert len(checkpoint["embeddings"]["edge_embeddings"]) == self.knowledge_graph.edge_count, f"Mismatch between the number of edges in the checkpoint ({len(checkpoint["embeddings"]["edge_embeddings"])}) and the current configuration ({self.knowledge_graph.edge_count})!"
 
-        if isinstance(self.encoder, GNN):
+        if self.encoder is not None:
             assert len(checkpoint["embeddings"]["node_embeddings"]) == len(self.knowledge_graph.node_type_to_index), f"Mismatch between the number of node types in the checkpoint ({len(checkpoint["nodes"])}) and the current configuration ({len(self.knowledge_graph.node_type_to_index)})!"
         else:
             assert len(checkpoint["embeddings"]["node_embeddings.0"]) == self.knowledge_graph.node_count, f"Mismatch between the number of nodes in the checkpoint ({len(checkpoint["embeddings"]["node_embeddings.0"])}) and the current configuration ({self.knowledge_graph.node_count})!"
@@ -1248,7 +1247,7 @@ class Architect(Module):
         logging.info("Best model successfully loaded.")
 
 
-    def get_batch_embeddings(self, knowledge_graph: KnowledgeGraph, batch: Tensor, mask: Tensor | None = None) -> Tensor:
+    def get_batch_embeddings(self, knowledge_graph: KnowledgeGraph, batch: Tensor, mask: Tensor | None = None) -> nn.Parameter:
         if isinstance(self.encoder, GNN):
             seed_nodes: Tensor = batch[:2].unique().cpu()
             hop_count: int = self.encoder.layer_count
@@ -1264,9 +1263,9 @@ class Architect(Module):
             # idx of the embeddings. It's not a logic problem as only the indices from the batch will be selected for the decoder,
             # which corresponds to the indices that are filled here.
             # TODO: See if making it a sparse tensor can spare memory
-            node_embeddings: torch.Tensor = torch.zeros((knowledge_graph.node_count, self.encoder_node_embedding_dimensions),
+            node_embeddings: nn.Parameter = nn.Parameter(torch.zeros((knowledge_graph.node_count, self.encoder_node_embedding_dimensions),
                                                     device = self.device,
-                                                    dtype = torch.float)
+                                                    dtype = torch.float))
 
             for node_type, index in input.node_mapping.items():
                 node_embeddings[index] = encoder_output[node_type]
@@ -1410,7 +1409,7 @@ class Architect(Module):
         """
         self.normalize_parameters()
         
-        if isinstance(self.encoder, GNN):
+        if self.encoder is not None:
             node_embeddings: torch.Tensor = torch.zeros((self.knowledge_graph.node_count, self.encoder_node_embedding_dimensions), device="cpu", dtype=torch.float)
 
             with torch.no_grad():

--- a/src/kgate/architect.py
+++ b/src/kgate/architect.py
@@ -2,10 +2,6 @@
 Architect class and methods to run a KGE model training, testing and inference from end to end.
 """
 
-from kgate.initializers import Node2VecInitializer
-from torch_geometric.nn import Node2Vec
-from kgate.initializers import FeatureInitializer
-from kgate import Initializer
 import csv
 import gc
 import logging
@@ -731,7 +727,7 @@ class Architect(Module):
         
         Options are random initialization, which is equivalent to just a lookup embedding,
         user-supplied features that can be learnt with a deep encoder, and Node2Vec."""
-        match self.config["initializer"]["name"]:
+        match self.config["model"]["initializer"]["name"]:
             case "Random":
                 initializer = Initializer()
             case "Feature":
@@ -740,15 +736,15 @@ class Architect(Module):
                 initializer = Node2VecInitializer(
                     edge_indices = self.knowledge_graph.edge_list[:, self.knowledge_graph.train_mask],
                     embedding_dimensions = self.node_embedding_dimensions,
-                    walk_length = self.config["initializer"]["walk_length"],
-                    context_size = self.config["initializer"]["context_size"],
+                    walk_length = self.config["model"]["initializer"]["walk_length"],
+                    context_size = self.config["model"]["initializer"]["context_size"],
                     output_directory = self.checkpoints_directory,
                     device = self.device
                 )
             case _:
-                raise NotImplementedError(f"The requested initializer {self.config["initializer"]["name"]} is not implemented.")
+                raise NotImplementedError(f"The requested initializer {self.config["model"]["initializer"]["name"]} is not implemented.")
             
-        logging.info(f"Using the {self.config["initializer"]["name"]} initializer")
+        logging.info(f"Using the {self.config["model"]["initializer"]["name"]} initializer")
         return initializer
 
     def initialize_model(self,
@@ -1238,17 +1234,17 @@ class Architect(Module):
         self.knowledge_graph.embeddings.load_state_dict(checkpoint["embeddings"])
 
         self.decoder.load_state_dict(checkpoint["decoder"], strict=False)
-        if "encoder" in checkpoint:
+        if "encoder" in checkpoint and self.encoder is not None:
             self.encoder.load_state_dict(checkpoint["encoder"])
+            self.encoder.to(self.device)
         
         self.knowledge_graph.embeddings.to(self.device)
         self.decoder.to(self.device)
-        self.encoder.to(self.device)
         logging.info("Best model successfully loaded.")
 
 
     def get_batch_embeddings(self, knowledge_graph: KnowledgeGraph, batch: Tensor, mask: Tensor | None = None) -> nn.Parameter:
-        if isinstance(self.encoder, GNN):
+        if self.encoder is not None:
             seed_nodes: Tensor = batch[:2].unique().cpu()
             hop_count: int = self.encoder.layer_count
 
@@ -1259,19 +1255,28 @@ class Architect(Module):
 
             encoder_output: Dict[str, Tensor] = self.encoder(input.x_dict, input.edge_index)
 
+            all_indices = torch.cat([
+                index for index in input.node_mapping.values()
+            ])
+
+            all_embeddings = torch.cat([
+                encoder_output[node_type] for node_type in input.node_mapping.keys()
+            ])
+
             # As I understand it, this tensor is larger than needs to be because it needs to account for every possible
             # idx of the embeddings. It's not a logic problem as only the indices from the batch will be selected for the decoder,
             # which corresponds to the indices that are filled here.
             # TODO: See if making it a sparse tensor can spare memory
-            node_embeddings: nn.Parameter = nn.Parameter(torch.zeros((knowledge_graph.node_count, self.encoder_node_embedding_dimensions),
-                                                    device = self.device,
-                                                    dtype = torch.float))
-
-            for node_type, index in input.node_mapping.items():
-                node_embeddings[index] = encoder_output[node_type]
-
+            node_embeddings = torch.zeros(
+                (knowledge_graph.node_count, self.encoder_node_embedding_dimensions),
+                device = self.device,
+                dtype = torch.float
+            ).index_put_(
+                (all_indices,),
+                all_embeddings
+            )
         else:
-            node_embeddings = self.node_embeddings[0]
+            node_embeddings = self.knowledge_graph.node_embeddings[0]
 
         return node_embeddings
 
@@ -1314,7 +1319,7 @@ class Architect(Module):
         if not self.skip_normalization:
             self.normalize_parameters()
 
-        return loss.item()
+        return loss
 
 
     def forward(self,

--- a/src/kgate/config_template.toml
+++ b/src/kgate/config_template.toml
@@ -48,12 +48,26 @@ theta_second_edge_type = 0.8
 node_embedding_dimensions = 256
 edge_embedding_dimensions = -1
 
+[model.initializer]
+# The initializer generates the initial embeddings for nodes and edges.
+# Depending on the initializer used, the dimensions of the initial embeddings
+# may not be the same as model.node_embedding_dimension and model.edge_embedding_dimension,
+# in which case using an encoder is mandatory
+# Supported options are:
+# - Random: all nodes and edges have random initial embeddings based on a xavier uniform function.
+# - Feature: the initial embeddings will be supplied by the user as node and edge features. If a node type doesn't have a feature, it will be randomly initialized as above.
+# - Node2Vec: use the Node2Vec random walk algorithm to initialize embeddings.
+name = "Random"
+
+# The following parameters are only used with Node2Vec
+walk_length = 10
+context_size = 8
+
 [model.encoder]
-# The encoder transforms the nodes and edges into embedding vectors
-# of size model.emb_dim and model.rel_emb_dim respectively.
+# The encoder aggregates the information from the initial embedding vectors
+# and outputs a new representation of size model.node_embedding_dimension and model.edge_embedding_dimension.
 # Read the documentation for more information about the different encoders.
 # Supported options are:
-# - Default: a simple lookup table, similar to a random initialization.
 # - GCN: Graph Convolutional Network proposed by Kipf & Welling 2017
 # - GAT: Graph Attention Network improvment proposed by Brody et al. 2021
 name = "Default" #Lookup table

--- a/src/kgate/decoders/bilinear.py
+++ b/src/kgate/decoders/bilinear.py
@@ -17,8 +17,7 @@ from torch import matmul, Tensor, nn, tensor_split
 from torch.nn.functional import normalize
 from torch.nn import Module
 
-from ..utils import initialize_embedding
-
+from ..initializers import Initializer
 
 
 class BilinearDecoder(Module):
@@ -295,7 +294,8 @@ class RESCAL(BilinearDecoder):
         self.edge_count = edge_count
         self.embedding_dimensions = embedding_dimensions
 
-        self.edge_embeddings_matrix = initialize_embedding(self.edge_count, self.embedding_dimensions * self.embedding_dimensions)
+        initializer = Initializer()
+        self.edge_embeddings_matrix = initializer.initialize_embedding(self.edge_count, self.embedding_dimensions * self.embedding_dimensions)
 
 
     def score(  self,

--- a/src/kgate/decoders/translational.py
+++ b/src/kgate/decoders/translational.py
@@ -26,7 +26,7 @@ from torchkge.utils.dissimilarities import  l1_dissimilarity, \
                                             l2_torus_dissimilarity, \
                                             el2_torus_dissimilarity
 
-from ..utils import initialize_embedding
+from ..initializers import Initializer
 
 
 
@@ -506,7 +506,8 @@ class TransH(TranslationalDecoder):
                 node_count: int,
                 edge_count: int):
         super().__init__()
-        self.normal_vector = initialize_embedding(edge_count, embedding_dimensions)
+        initializer = Initializer()
+        self.normal_vector = initializer.initialize_embedding(edge_count, embedding_dimensions)
         self.dissimilarity = l2_dissimilarity
 
         self.evaluated_projections = False
@@ -795,7 +796,8 @@ class TransR(TranslationalDecoder):
         self.node_embedding_dimensions = node_embedding_dimensions
         self.edge_embedding_dimensions = edge_embedding_dimensions
 
-        self.projection_matrix = initialize_embedding(node_count, edge_embedding_dimensions * node_embedding_dimensions)
+        initializer = Initializer()
+        self.projection_matrix = initializer.initialize_embedding(node_count, edge_embedding_dimensions * node_embedding_dimensions)
 
         self.dissimilarity = l2_dissimilarity
 
@@ -1097,10 +1099,11 @@ class TransD(TranslationalDecoder):
         self.edge_count = edge_count
         self.node_embedding_dimensions = node_embedding_dimensions
         self.edge_embedding_dimensions = edge_embedding_dimensions
-
+        
+        initializer = Initializer()
         # TODO: Might be changed to have 2 embedding spaces instead (meaning it will be encoded by a GNN if present)
-        self.node_projection_vector = initialize_embedding(self.node_count, self.node_embedding_dimensions)
-        self.edge_projection_vector = initialize_embedding(self.edge_count, self.edge_embedding_dimensions)
+        self.node_projection_vector = initializer.initialize_embedding(self.node_count, self.node_embedding_dimensions)
+        self.edge_projection_vector = initializer.initialize_embedding(self.edge_count, self.edge_embedding_dimensions)
 
         self.dissimilarity = l2_dissimilarity
 

--- a/src/kgate/encoders.py
+++ b/src/kgate/encoders.py
@@ -15,28 +15,14 @@ from torch import Tensor
 import torch.nn as nn
 import torch.nn.functional as F
 
-from torch_geometric.nn import GATv2Conv, HeteroConv, Node2Vec, SAGEConv
-
+from torch_geometric.nn import GATv2Conv, HeteroConv, SAGEConv
+""
 
 logging_level = logging.INFO
 logging.basicConfig(
     level = logging_level,  
     format = "%(asctime)s - %(levelname)s - %(message)s" 
 )
-
-
-class DefaultEncoder(nn.Module):
-    """
-    Encoder used by default if none is precised in the config file.
-    
-    This class inherits from the PyTorch `nn.module` class, without any addition:
-    https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html
-    
-    """
-    def __init__(self):
-        super().__init__()
-
-
 
 class GNN(nn.Module):
     """
@@ -272,91 +258,3 @@ class GCNEncoder(GNN):
                 aggr = self.aggregation
                 ).to(device)
             self.convolutions.append(convolution)
-
-
-
-class Node2VecEncoder:
-    """
-    Implementation of node2vec model detailed in the paper referenced below.
-
-    References
-    ----------
-    Aditya Grover, Jure Leskovec
-    `node2vec: Scalable Feature Learning for Networks`
-    https://arxiv.org/pdf/1607.00653
-    In Proceedings of the 22nd ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 2016.
-
-    Arguments
-    ---------
-    edge_indices: torch.Tensor
-        Indices of edges.
-    embedding_dimensions: int
-        Dimensions of embedding, both of nodes and edges.
-    walk_length: int
-        The walk length.
-    context_size: int
-        The actual context size which is considered for positive samples.
-        This parameter increases the effective sampling rate by reusing samples across different source nodes.
-    device: torch.device or Literal["cuda", "cpu"]
-        Indicate if data should be sent to GPU or CPU.
-        GPU is referenced to as Cuda.
-    output_directory: Path
-        Path to the directory where files will be created.
-
-    Attributes
-    ----------
-    device: torch.device or Literal["cuda", "cpu"]
-        Indicate if data should be sent to GPU or CPU.
-        GPU is referenced to as Cuda.
-    output_directory: Path
-        Path to the directory where files will be created.
-    model: torch_geometric.nn.Node2Vec
-        The Node2Vec model object.
-        Node2Vec documentation: https://pytorch-geometric.readthedocs.io/en/2.5.1/generated/torch_geometric.nn.models.Node2Vec.html
-    loader: TODO.type
-        TODO.What_that_variable_is_or_does
-    optimizer: TODO.type
-        TODO.What_that_variable_is_or_does
-    
-    """
-    def __init__(self,
-                edge_indices: Tensor,
-                embedding_dimensions: int,
-                walk_length: int,
-                context_size: int,
-                output_directory: Path,
-                device: torch.device | Literal["cuda", "cpu"] = "cuda",
-                **node2vec_kwargs):
-        self.device = device
-        self.output_directory = output_directory
-        self.model = Node2Vec(
-            edge_index = edge_indices,
-            embedding_dim = embedding_dimensions,
-            walk_length = walk_length,
-            context_size = context_size,
-            **node2vec_kwargs
-            ).to(device)
-
-        workers_count = 4 if sys.platform == 'linux' else 0
-        self.loader = self.model.loader(batch_size = 128, shuffle = True, num_workers = workers_count)
-        self.optimizer = torch.optim.SparseAdam(list(self.model.parameters()), lr = 0.01)
-    
-    
-    def generate_embeddings(self):
-        """
-        TODO.What_the_function_does_about_globally
-        
-        """
-        for epoch in range(1,101):
-            epoch_loss = 0
-            for positive_random_walk, negative_random_walk in tqdm(self.loader):
-                self.optimizer.zero_grad()
-                loss = self.model.loss(positive_random_walk.to(self.device), negative_random_walk.to(self.device))
-                loss.backward()
-                self.optimizer.step()
-                epoch_loss += loss.item()
-            
-            logging.info(f"Epoch {epoch: 03d}, Embedding Loss: {loss: .4f}")
-
-        torch.save(self.model.embedding, self.output_directory.joinpath("embeddings_node2vec.pt"))
-        logging.info(f"Embedding fully generated, saved in {self.output_directory}")

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -270,7 +270,6 @@ class LinkPredictionEvaluator:
         self.filtered_rank_true_tails = empty(size = (len(evaluated_subset),)).long().to(device)
 
         dataloader = DataLoader(evaluated_subset, batch_size = batch_size)
-        graphindices = knowledge_graph.graphindices.to(device) # this is the training graphindices
         if decoder is not None and hasattr(decoder,"embedding_spaces"):
             encoder_node_embedding_dimensions: int = self.embedding_dimensions * decoder.embedding_spaces
         else:

--- a/src/kgate/evaluators.py
+++ b/src/kgate/evaluators.py
@@ -27,7 +27,7 @@ from torchkge.data_structures import SmallKG
 if TYPE_CHECKING:
     from .architect import Architect
 from .decoders import BilinearDecoder, ConvolutionalDecoder, TranslationalDecoder
-from .encoders import GNN, DefaultEncoder
+from .encoders import GNN
 from .knowledgegraph import KnowledgeGraph
 from .samplers import NegativeSampler, PositionalNegativeSampler, BernoulliNegativeSampler, UniformNegativeSampler, MixedNegativeSampler
 from .utils import filter_scores
@@ -222,7 +222,7 @@ class LinkPredictionEvaluator:
 
     def evaluate(self,
                 batch_size: int,
-                encoder: DefaultEncoder | GNN,
+                encoder: GNN | None,
                 decoder: BilinearDecoder | ConvolutionalDecoder | TranslationalDecoder,
                 evaluated_subset: Subset[KnowledgeGraph],
                 node_embeddings: nn.ParameterList,
@@ -236,7 +236,7 @@ class LinkPredictionEvaluator:
         ---------
         batch_size: int
             Size of the current batch.
-        encoder: DefaultEncoder or GNN
+        encoder: GNN, optional
             Encoder model to embed the nodes. Deactivated with DefaultEncoder.
         decoder: BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder
             Decoder model to evaluate.
@@ -277,7 +277,7 @@ class LinkPredictionEvaluator:
             encoder_node_embedding_dimensions: int = self.embedding_dimensions
 
         # Aggregate information for all nodes
-        if isinstance(encoder, GNN):
+        if encoder is not None:
 
             evaluation_node_embeddings: torch.Tensor = torch.zeros((knowledge_graph.node_count,
                                                             encoder_node_embedding_dimensions),

--- a/src/kgate/inference.py
+++ b/src/kgate/inference.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from torch_geometric.utils import k_hop_subgraph
 
-from .encoders import DefaultEncoder, GNN
+from .encoders import GNN
 from .decoders import TranslationalDecoder, BilinearDecoder, ConvolutionalDecoder
 from .knowledgegraph import KnowledgeGraph
 from .utils import filter_scores
@@ -114,7 +114,7 @@ class EdgeInference:
                 *,
                 top_k: int,
                 batch_size: int,
-                encoder: DefaultEncoder | GNN,
+                encoder: GNN | None,
                 decoder: TranslationalDecoder | BilinearDecoder | ConvolutionalDecoder,
                 node_embeddings: nn.ParameterList, 
                 edge_embeddings: nn.Embedding, 
@@ -144,9 +144,8 @@ class EdgeInference:
         **batch_size** *(int, keyword-only)*
         : Size of the current batch.
         
-        **encoder** *(DefaultEncoder or GNN, keyword-only)*
-        : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        
+        **encoder** *( GNN, keyword-only)*
+        : Encoder model to embed the nodes.     
         **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder)*
         : Decoder model to evaluate.
         
@@ -193,7 +192,7 @@ class EdgeInference:
                 head_indices, tail_indices = batch[0], batch[1]
                 embeddings = torch.zeros(len(head_indices), node_embeddings[0].shape[1], device=device, dtype=torch.float)
 
-                if isinstance(encoder, GNN):
+                if encoder is not None:
                     seed_nodes = batch.unique()
                     hop_count = encoder.n_layers
                     edge_list = self.kg.edge_list
@@ -271,7 +270,7 @@ class NodeInference:
                 top_k: int,
                 missing_triplet_part: Literal["head", "tail"],
                 batch_size: int,
-                encoder: DefaultEncoder | GNN,
+                encoder: GNN | None,
                 decoder: TranslationalDecoder | BilinearDecoder | ConvolutionalDecoder,
                 node_embeddings: nn.ParameterList, 
                 edge_embeddings: nn.Embedding,
@@ -303,9 +302,8 @@ class NodeInference:
         **batch_size** *(int, keyword-only)*
         : Size of the current batch.
         
-        **encoder** *(DefaultEncoder or GNN, keyword-only)*
-        : Encoder model to embed the nodes. Deactivated with DefaultEncoder.
-        
+        **encoder** *( GNN, keyword-only)*
+        : Encoder model to embed the nodes. Deactivated with        
         **decoder** *(BilinearDecoder or ConvolutionalDecoder or TranslationalDecoder, keyword-only)*
         : Decoder model to evaluate.
         

--- a/src/kgate/initializers.py
+++ b/src/kgate/initializers.py
@@ -3,7 +3,7 @@ from kgate import KnowledgeGraph
 import pandas as pd
 import torch
 import torch.nn as nn
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Any
 import logging
 from pathlib import Path
 from torch_geometric.nn import Node2Vec

--- a/src/kgate/initializers.py
+++ b/src/kgate/initializers.py
@@ -1,0 +1,269 @@
+from kgate import KnowledgeGraph
+
+import pandas as pd
+import torch
+import torch.nn as nn
+from typing import Tuple, Dict
+import logging
+from pathlib import Path
+from torch_geometric.nn import Node2Vec
+import sys
+from tqdm import tqdm
+
+class Initializer:
+    """Base class for initializing node and edge embedding."""
+    def initialize_embedding(self, 
+                            sample_count: int,
+                            embedding_dimensions: int,
+                            device: torch.device | str) -> nn.Parameter:
+        """
+        Initialize embeddings with number of nodes/edges and embedding dimensions.
+        
+        Use of a Xavier uniform distribution.
+        See PyTorch documentation: https://docs.pytorch.org/docs/stable/nn.init.html#torch.nn.init.xavier_uniform_
+        
+        Arguments
+        ---------
+        sample_count: int
+            Number of nodes/edges in the embedding.
+        embedding_dimensions: int
+            Dimensions of embeddings.
+        device: torch.device or str, default to "cpu"
+            Indicate if data should be sent to GPU or CPU.
+            GPU is referenced to as Cuda.
+            
+        Returns
+        -------
+        embedding: nn.Embedding
+            Embedding object with given parameters.
+        
+        """
+        embedding = nn.Parameter(torch.empty((sample_count, embedding_dimensions), device = device))
+        nn.init.xavier_uniform_(embedding.data)
+        
+        return embedding
+
+    def initialize_all_embeddings(self, 
+                                    knowledge_graph: KnowledgeGraph,
+                                    *,
+                                    node_embedding_dimensions: int, 
+                                    edge_embedding_dimensions: int,
+                                    device: torch.device | str = "cpu",
+                                    inplace: bool = False
+                                ) -> Tuple[nn.ParameterList, nn.Parameter] | None:
+        """Initialize all node and edge embeddings.
+
+        This is a generic function that calls the initializer.initialize_embedding(). Refer to the 
+        initializer's `initialize_embedding` method for the actual initialization logic.
+
+        Arguments
+        ---------
+        knowledge_graph: KnowledgeGraph
+            The knowledge graph for which the embeddings are initialized.
+        node_embedding_dimensions: int
+            The embedding dimensions of the nodes.
+        edge_embedding_dimensions: int
+            The embedding dimensions of the edges. For most models, this is the same as above.
+        device: torch.device or str, optional, defaults to "cpu"
+            The PyTorch device where the embeddings should be created in.
+        inplace: bool, optional, defaults to False
+            Whether the embeddings should be returned or directly applied to the knowledge graph.
+
+        Returns
+        -------
+        Only if inplace = False
+        node_embeddings: nn.ParameterList
+            The generated node embeddings
+        edge_embeddings: nn.Parameter
+            The generated edge embeddings
+        """
+        node_embeddings = nn.ParameterList()
+        index_to_node_type = {value: key for key,value in knowledge_graph.node_type_to_index.items()}
+        for node_type in knowledge_graph.node_type_to_global:
+            node_count = knowledge_graph.node_type_to_global[node_type].size(0)
+
+            node_embeddings.append(self.initialize_embedding(node_count, node_embedding_dimensions, device))
+    
+        edge_embeddings = self.initialize_embedding(knowledge_graph.edge_count, edge_embedding_dimensions, device)
+
+        if inplace:
+            knowledge_graph.embeddings = node_embeddings, edge_embeddings
+        else:
+            return node_embeddings, edge_embeddings
+    
+
+class FeatureInitializer(Initializer):
+    """
+    Initializer using user-supplied features
+    """
+    def __init__(self, node_features: Dict[str, pd.DataFrame], edge_features: pd.DataFrame) -> None:
+        self.node_features = node_features
+        self.edge_features = edge_features
+
+    def initialize_all_embeddings(self,
+                                    knowledge_graph: KnowledgeGraph,
+                                    *,
+                                    node_embedding_dimensions: int, 
+                                    edge_embedding_dimensions: int,
+                                    device: torch.device | str = "cpu",
+                                    inplace: bool = False
+                                ) -> Tuple[nn.ParameterList, nn.Parameter] | None:
+        """
+        Initialize all node and edge embeddings using user-supplied features.
+
+        If a node or edge type was not provided with any feature, its embeddings will be 
+        randomly initialized.
+
+        Arguments
+        ---------
+        knowledge_graph: KnowledgeGraph
+            The knowledge graph for which the embeddings are initialized.
+        node_embedding_dimensions: int
+            The embedding dimensions of the nodes.
+        edge_embedding_dimensions: int
+            The embedding dimensions of the edges. For most models, this is the same as above.
+        device: torch.device or str, optional, defaults to "cpu"
+            The PyTorch device where the embeddings should be created in.
+        inplace: bool, optional, defaults to False
+            Whether the embeddings should be returned or directly applied to the knowledge graph.
+
+        Returns
+        -------
+        Only if inplace = False
+        node_embeddings: nn.ParameterList
+            The generated node embeddings
+        edge_embeddings: nn.Parameter
+            The generated edge embeddings
+        """
+        node_embeddings = nn.ParameterList()
+        index_to_node_type = {value: key for key,value in knowledge_graph.node_type_to_index.items()}
+        for node_type in knowledge_graph.node_type_to_global:
+            node_count = knowledge_graph.node_type_to_global[node_type].size(0)
+
+            if node_type in self.node_features:
+                current_feature: pd.DataFrame = self.node_features[node_type]
+                
+                assert current_feature.shape[0] == node_count, f"The length of the given attribute ({current_feature.shape[0]}) must match the number of nodes of this type ({node_count})."
+                input_features = torch.empty((node_count, current_feature.shape[1]), dtype = torch.float, device = device)
+                
+                for node in current_feature.index:
+                    node_index = knowledge_graph.node_to_index[node]
+                    node_type_index = knowledge_graph.node_types[node_index]
+                    local_index = knowledge_graph.global_to_local_indices[node_index]
+                    assert node_type_index == knowledge_graph.node_type_to_index[node_type], f"The node {node} is given as {node_type} but registered as {index_to_node_type[str(node_type_index)]} in the KG."
+
+                    input_features[local_index] = torch.tensor(current_feature.loc[node], dtype = torch.float, device = device)
+                
+                node_embeddings.append(nn.Parameter(input_features))
+            else:
+                logging.warning(f"Node type {node_type} was not given any feature, will initialize random embeddings.")
+                embeddings: nn.Parameter = self.initialize_embedding(node_count, node_embedding_dimensions, device)
+                node_embeddings.append(embeddings)
+
+        if self.edge_features is not None:
+            assert self.edge_features.shape[0] == knowledge_graph.edge_count, f"The length of the edge features ({self.edge_features.shape[0]}) must match the number of edges in the graph ({knowledge_graph.edge_count})."
+            edge_embeddings = torch.empty((knowledge_graph.edge_count, self.edge_features.shape[1]), dtype = torch.float, device = device)
+
+            for edge in self.edge_features.index:
+                edge_index = knowledge_graph.edge_to_index[edge]
+                edge_embeddings[edge_index] = torch.tensor(self.edge_features.loc[edge], dtype = torch.float, device = device)
+        else:
+            edge_embeddings: nn.Parameter = self.initialize_embedding(knowledge_graph.edge_count, edge_embedding_dimensions, device)
+        if inplace:
+            knowledge_graph.embeddings = node_embeddings, edge_embeddings
+        else:
+            return node_embeddings, edge_embeddings
+
+class Node2VecInitializer(Initializer):
+    """
+    Implementation of node2vec model detailed in the paper referenced below.
+
+    References
+    ----------
+    Aditya Grover, Jure Leskovec
+    `node2vec: Scalable Feature Learning for Networks`
+    https://arxiv.org/pdf/1607.00653
+    In Proceedings of the 22nd ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 2016.
+
+    Arguments
+    ---------
+    edge_indices: torch.Tensor
+        Indices of edges.
+    embedding_dimensions: int
+        Dimensions of embedding, both of nodes and edges.
+    walk_length: int
+        The walk length.
+    context_size: int
+        The actual context size which is considered for positive samples.
+        This parameter increases the effective sampling rate by reusing samples across different source nodes.
+    device: torch.device or Literal["cuda", "cpu"]
+        Indicate if data should be sent to GPU or CPU.
+        GPU is referenced to as Cuda.
+    output_directory: Path
+        Path to the directory where files will be created.
+
+    Attributes
+    ----------
+    device: torch.device or Literal["cuda", "cpu"]
+        Indicate if data should be sent to GPU or CPU.
+        GPU is referenced to as Cuda.
+    output_directory: Path
+        Path to the directory where files will be created.
+    model: torch_geometric.nn.Node2Vec
+        The Node2Vec model object.
+        Node2Vec documentation: https://pytorch-geometric.readthedocs.io/en/2.5.1/generated/torch_geometric.nn.models.Node2Vec.html
+    loader: TODO.type
+        TODO.What_that_variable_is_or_does
+    optimizer: TODO.type
+        TODO.What_that_variable_is_or_does
+    
+    """
+    def __init__(self,
+                edge_indices: torch.Tensor,
+                embedding_dimensions: int,
+                walk_length: int,
+                context_size: int,
+                output_directory: Path,
+                device: torch.device | str = "cuda",
+                **node2vec_kwargs) -> None:
+        self.device = device
+        self.output_directory = output_directory
+        self.model = Node2Vec(
+            edge_index = edge_indices,
+            embedding_dim = embedding_dimensions,
+            walk_length = walk_length,
+            context_size = context_size,
+            **node2vec_kwargs
+            ).to(device)
+
+        workers_count = 4 if sys.platform == 'linux' else 0
+        self.loader = self.model.loader(batch_size = 128, shuffle = True, num_workers = workers_count)
+        self.optimizer = torch.optim.SparseAdam(list(self.model.parameters()), lr = 0.01)
+    
+    
+    def generate_all_embeddings(self,
+                                knowledge_graph: KnowledgeGraph,
+                                *,
+                                device: torch.device | str = "cpu",
+                                inplace: bool = False,
+                                **_) -> Any | None:
+        """
+        Generate initial embeddings using random walk
+        """
+        for epoch in range(1,101):
+            epoch_loss = 0
+            for positive_random_walk, negative_random_walk in tqdm(self.loader):
+                self.optimizer.zero_grad()
+                loss = self.model.loss(positive_random_walk.to(self.device), negative_random_walk.to(self.device))
+                loss.backward()
+                self.optimizer.step()
+                epoch_loss += loss.item()
+            
+            logging.info(f"Epoch {epoch: 03d}, Embedding Loss: {loss: .4f}")
+
+        torch.save(self.model.embedding, self.output_directory.joinpath("embeddings_node2vec.pt"))
+        logging.info(f"Embedding fully generated, saved in {self.output_directory}")
+
+        if inplace:
+            #TODO
+            pass

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -603,7 +603,7 @@ class KnowledgeGraph(Dataset):
     def generate_masks(self,
                 split_proportions: Tuple[float, float, float] = (0.8, 0.1, 0.1), 
                 sizes: Tuple[int, int, int] | None = None
-                ) -> Tuple[Self, Self, Self]:
+                ) -> None:
         """
         Generate the masks corresponding to three subsets of the knowledge graph: train, validation, test
 
@@ -858,7 +858,7 @@ class KnowledgeGraph(Dataset):
             edge_triplets = self.graphindices[:, self.graphindices[2] == edge_index]
             triplets_indices = edge_triplets[3].unique()
             # Create a new ID for the reverse edge
-            reverse_edge_index = len(self.edge_to_index)
+            reverse_edge_index = self.edge_count
             
             self.edge_to_index[reverse_edge] = reverse_edge_index
 
@@ -1166,17 +1166,17 @@ class KnowledgeGraph(Dataset):
         device = self.node_embeddings[0].device
 
         if mask is not None:
-            edge_list = self.edge_list[:, mask]
+            graphindices = self.graphindices[:, mask]
         else:
-            edge_list = self.edge_list
+            graphindices = self.graphindices
 
         subset, edge_index, mapping, edge_mask = k_hop_subgraph(
             node_idx = seed_nodes,
             num_hops = hop_count,
-            edge_index = edge_list
+            edge_index = graphindices[:2]
         )
 
-        subgraph = self.graphindices[:, edge_mask]
+        subgraph = graphindices[:, edge_mask]
 
         # All seed nodes not present in the subgraph are put in this dictionary 
         # to be used in the self-loop addition at the end of this function        

--- a/src/kgate/knowledgegraph.py
+++ b/src/kgate/knowledgegraph.py
@@ -1298,8 +1298,8 @@ class KnowledgeGraph(Dataset):
         """
         self.triplet_types = [triplet for triplet in self.triplet_types if triplet[1] != "self"]
 
-    @staticmethod
-    def from_hetero_data(hetero_data: HeteroData) -> KnowledgeGraph:
+    @classmethod
+    def from_hetero_data(cls, hetero_data: HeteroData) -> "KnowledgeGraph":
         """
         Create a new KGATE KnowledgeGraph instance from the PyTorch Geometric HeteroData object.
         
@@ -1317,10 +1317,11 @@ class KnowledgeGraph(Dataset):
         # TODO for PyTorch Geometric compatibility
         pass
 
-    @staticmethod
-    def from_torchkge(  torchkge_kg: torchkge.KnowledgeGraph,
+    @classmethod
+    def from_torchkge(  cls,
+                        torchkge_kg: torchkge.KnowledgeGraph,
                         metadata: pd.DataFrame | None = None
-                        ) -> KnowledgeGraph:
+                        ) -> "KnowledgeGraph":
         """
         Create a new KGATE KnowledgeGraph instance from the TorchKGE KnowledgeGraph object.
         

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -86,7 +86,9 @@ def prepare_knowledge_graph(config: dict,
         if kg is not None:
             if isinstance(kg, torchkge.KnowledgeGraph):
                 knowledge_graph = KnowledgeGraph.from_torchkge(kg, metadata)
-            elif not isinstance(kg, KnowledgeGraph):
+            elif isinstance(kg, KnowledgeGraph):
+                knowledge_graph = kg
+            else:
                 raise NotImplementedError(f"Knowledge graph type {type(kg)} is not supported. Supported knowledge graph types are KGATE's and TorchKGE's.")
         elif dataframe is not None:
             knowledge_graph = KnowledgeGraph(dataframe = dataframe, metadata = metadata)

--- a/src/kgate/preprocessing.py
+++ b/src/kgate/preprocessing.py
@@ -455,7 +455,6 @@ def clean_cartesians(
                 all_triplet_indices_to_move.extend(triplet_indices.tolist())
             
         if all_triplet_indices_to_move:
-            knowledge_graph.train_mask[all_triplet_indices_to_move] = False
-            knowledge_graph.validation_mask[all_triplet_indices_to_move] = False
-            knowledge_graph.test_mask[all_triplet_indices_to_move] = True
+            knowledge_graph.remove_triplets_from_training(all_triplet_indices_to_move)
+
 

--- a/src/kgate/samplers.py
+++ b/src/kgate/samplers.py
@@ -578,7 +578,7 @@ class PositionalNegativeSampler(BernoulliNegativeSampler):
         # Needs padding each tensors to the same length though
         for i in range(corrupted_head_count):
             edge_index = corrupted_head_batch[2][i]
-            choices: Tensor = self.possible_heads[edge_index]
+            choices: Tensor = self.possible_heads[edge_index.item()]
             if len(choices) == 0:
                 # In this case the edge i has never been used with any head
                 # Choose one node at random
@@ -616,7 +616,7 @@ class PositionalNegativeSampler(BernoulliNegativeSampler):
         triplets = [0] * (batch_size - corrupted_head_count) if len(self.knowledge_graph.node_type_to_index) == 1 else []
         for i in range(batch_size - corrupted_head_count):
             edge_index = corrupted_tail_batch[2][i]
-            choices: Tensor = self.possible_tails[edge_index]
+            choices: Tensor = self.possible_tails[edge_index.item()]
             if len(choices) == 0:
                 # In this case the edge i has never been used with any tail
                 # Choose one node at random

--- a/src/kgate/utils.py
+++ b/src/kgate/utils.py
@@ -312,38 +312,6 @@ def find_best_model(directory: Path) -> Path | None:
     
     return best_model_path
     
-    
-def initialize_embedding(embedding_count: int,
-                        embedding_dimensions: int,
-                        device: str = "cpu"
-                        ) -> nn.Embedding:
-    """
-    Initialize embeddings with number of nodes/edges and embedding dimensions.
-    
-    Use of a Xavier uniform distribution.
-    See PyTorch documentation: https://docs.pytorch.org/docs/stable/nn.init.html#torch.nn.init.xavier_uniform_
-    
-    Arguments
-    ---------
-    embedding_count: int
-        Number of nodes/edges in the embedding.
-    embedding_dimensions: int
-        Dimensions of embeddings.
-    device: str, "cuda" or "cpu", default to "cpu"
-        Indicate if data should be sent to GPU or CPU.
-        GPU is referenced to as Cuda.
-        
-    Returns
-    -------
-    embedding: nn.Embedding
-        Embedding object with given parameters.
-    
-    """
-    embedding = nn.Embedding(embedding_count, embedding_dimensions, device = device)
-    nn.init.xavier_uniform_(embedding.weight.data)
-    
-    return embedding
-
 
 def read_train_metrics(train_metrics_file: Path
                         ) -> pd.DataFrame:


### PR DESCRIPTION
<!-- Once you have read these comments, you are free to remove them -->

<!-- Feel free to look at other PRs for examples -->

## What are the changes for using KGATE?
<!-- Summarize what the changes are from a user perspective on the application -->
Embedding initialization is now taken care of by a dedicated class, `Initializer`, which can be called at any point given a knowledge graph and target embedding dimensions. Three initializer exist:
- Default : Random initialization of all embeddings
- Feature : Use a user-supplied dictionary of features, and randomly initialize all nodes and edges without one.
- Node2Vec : Run a Node2Vec training to get the initial embeddings.

Resolves #24 

## Why am I making these changes?
So far, embedding initialization was only present in the Architect at several steps, which could both be ambiguous and didn't fit with the objective of KGATE to also be a complete toolbox without the need of the Architect, but also to make the Architect itself completely modular. In addition, new ways to initialize the data will now be easier to implement.

## What are the changes from a developer perspective?
A new file has been added: `initializers.py`, which contains the base class and all the initializers.


## Checklist
- [ ] **I'm using `dev` as my base branch**
- [x] There is no overlap with another PR
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com//BAUDOTlab/KGATE/blob/dev/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I maintained consistency with the project's text
  - [x] Variables have consistent names
  - [x] All comments are in American English
- [x] I have tested the changes manually

<!--
TODO, rework/add: for when the project has tests
- [ ] The full test suite still passes (`pnpm test:silent`)
  - [ ] I have created new automated tests (`pytest tests/`) or updated existing tests related to the PR's changes
-->